### PR TITLE
Provide the frolint as executable script

### DIFF
--- a/packages/frolint/index.js
+++ b/packages/frolint/index.js
@@ -1,7 +1,9 @@
+#!/usr/bin/env node
+
 const ogh = require("@yamadayuki/ogh");
-const { preCommitHook } = require("./preCommitHook");
+const { hook } = require("./preCommitHook");
 
 ogh
   .entrypoint("frolint", { scriptPath: "index.js", hooks: ["pre-commit"] })
-  .registerPerformHook(preCommitHook)
+  .registerPerformHook(hook)
   .parse(process.argv);

--- a/packages/frolint/package.json
+++ b/packages/frolint/package.json
@@ -2,6 +2,7 @@
   "name": "frolint",
   "version": "0.1.4",
   "main": "index.js",
+  "bin": "index.js",
   "author": "Yuki Yamada <yamada@wantedly.com>",
   "license": "MIT",
   "dependencies": {

--- a/packages/frolint/preCommitHook.js
+++ b/packages/frolint/preCommitHook.js
@@ -141,6 +141,10 @@ function hook(args, config) {
     files = getAllFiles(rootDir, isTypescript ? [".js", ".jsx", ".ts", ".tsx"] : [".js", ".jsx"]);
   }
 
+  if (files.length === 0) {
+    return;
+  }
+
   const eslintConfigPackage = isTypescript ? "eslint-config-wantedly-typescript" : "eslint-config-wantedly";
 
   // Enable to resolve the eslint-config-wantedly packages


### PR DESCRIPTION
## WHY

We want to execute `frolint` as a command.

## WHAT

I'll publish the `frolint` command. When the user invokes the `frolint` command, this command analyzes the all JS / TS files under the git control.