### PR TITLE
Support formatter option

### DIFF
--- a/packages/frolint/package.json
+++ b/packages/frolint/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@yamadayuki/ogh": "^0.1.0",
+    "arg": "^4.1.0",
     "chalk": "^2.4.2",
     "eslint": "^5.14.1",
     "eslint-config-wantedly": "^0.1.4",

--- a/packages/frolint/preCommitHook.js
+++ b/packages/frolint/preCommitHook.js
@@ -4,6 +4,7 @@ const eslint = require("eslint");
 const fs = require("fs");
 const path = require("path");
 const chalk = require("chalk");
+const arg = require("arg");
 
 const { green, red, yellow } = chalk;
 
@@ -137,12 +138,26 @@ function optionsFromConfig(config) {
   };
 }
 
+function parseArgs(args) {
+  const result = arg(
+    {
+      "--formatter": String,
+    },
+    { argv: args }
+  );
+
+  return {
+    formatter: result["--formatter"],
+  };
+}
+
 /**
  * @param {string[]} args process.argv
  * @param {...Froconf} config a config of froconf
  */
 function hook(args, config) {
   const rootDir = ogh.extractGitRootDirFromArgs(args);
+  const argResult = parseArgs(args);
   const { isTypescript, formatter } = optionsFromConfig(config);
   const isPreCommit = ogh.extractHookFromArgs(args) === "pre-commit";
 
@@ -181,7 +196,7 @@ function hook(args, config) {
     }
   });
 
-  const reported = reportToConsole(report, rootDir, formatter);
+  const reported = reportToConsole(report, rootDir, argResult.formatter || formatter);
 
   if (isPreCommit) {
     const stagedErrorCount = reported

--- a/packages/frolint/preCommitHook.js
+++ b/packages/frolint/preCommitHook.js
@@ -41,18 +41,22 @@ function getRelativePath(cwd, absolutePath) {
   return absolutePath;
 }
 
-function applyEslint(args, files) {
-  const rootDir = ogh.extractGitRootDirFromArgs(args);
-
+function getCli(cwd) {
   const cli = new eslint.CLIEngine({
     baseConfig: {
       extends: ["wantedly"],
     },
     fix: true,
-    cwd: rootDir,
+    cwd,
   });
 
-  return cli.executeOnFiles(files.filter(isSupportedExtension));
+  return cli;
+}
+
+function applyEslint(args, files) {
+  const rootDir = ogh.extractGitRootDirFromArgs(args);
+
+  return getCli(rootDir).executeOnFiles(files.filter(isSupportedExtension));
 }
 
 function reportNoop() {
@@ -70,7 +74,7 @@ function formatResults(results, cwd) {
     });
 }
 
-function reportToConsole(report, cwd) {
+function reportWithFrolintFormat(report, cwd) {
   const { results, errorCount, warningCount } = report;
 
   if (errorCount === 0 && warningCount === 0) {
@@ -101,20 +105,35 @@ function reportToConsole(report, cwd) {
   return reported;
 }
 
+function reportToConsole(report, cwd, formatter) {
+  if (formatter) {
+    const cli = getCli(cwd);
+    const format = cli.getFormatter(formatter);
+
+    console.log(format(report.results));
+
+    return formatResults(report.results, cwd);
+  }
+
+  return reportWithFrolintFormat(report, cwd);
+}
+
 /**
  * A config of frolint
  * @typedef {Object} Froconf
  * @property {boolean} typescript - Indicates whether the eslint config uses @typescript-eslint or not.
+ * @property {string} [formatter] - Indicates the formatter for console
  */
 
 /**
  * @param {...Froconf} config a config of froconf
  */
-function flagsFromConfig(config) {
-  const { typescript } = config;
+function optionsFromConfig(config) {
+  const { typescript, formatter } = config;
 
   return {
     isTypescript: typeof typescript === "boolean" ? typescript : true,
+    formatter,
   };
 }
 
@@ -124,7 +143,7 @@ function flagsFromConfig(config) {
  */
 function hook(args, config) {
   const rootDir = ogh.extractGitRootDirFromArgs(args);
-  const { isTypescript } = flagsFromConfig(config);
+  const { isTypescript, formatter } = optionsFromConfig(config);
   const isPreCommit = ogh.extractHookFromArgs(args) === "pre-commit";
 
   let files = [];
@@ -139,10 +158,6 @@ function hook(args, config) {
     };
   } else {
     files = getAllFiles(rootDir, isTypescript ? [".js", ".jsx", ".ts", ".tsx"] : [".js", ".jsx"]);
-  }
-
-  if (files.length === 0) {
-    return;
   }
 
   const eslintConfigPackage = isTypescript ? "eslint-config-wantedly-typescript" : "eslint-config-wantedly";
@@ -166,7 +181,7 @@ function hook(args, config) {
     }
   });
 
-  const reported = reportToConsole(report, rootDir);
+  const reported = reportToConsole(report, rootDir, formatter);
 
   if (isPreCommit) {
     const stagedErrorCount = reported


### PR DESCRIPTION
## WHY

We provide the `frolint` original formatter as default. I supposed that there are users who want to use the ESLint formatter (e.g. `stylish`, `checkstyle`, `json`, etc.).

## WHAT

I decided to support formatter option.

The users can specify the formatter in a config. For example in `package.json`
```json
{
  "frolint": {
    "formatter": "stylish"
  }
}
```

Or specify as CLI option.

```sh
frolint --formatter=checkstyle
```