### PR TITLE
Ignore conditional expression

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -943,7 +943,7 @@ Object {
     "error",
     2,
     Object {
-      "SwitchCase": 0,
+      "SwitchCase": 1,
       "flatTernaryExpressions": false,
       "ignoreComments": false,
       "ignoredNodes": Array [

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -942,6 +942,14 @@ Object {
   "indent": Array [
     "error",
     2,
+    Object {
+      "SwitchCase": 0,
+      "flatTernaryExpressions": false,
+      "ignoreComments": false,
+      "ignoredNodes": Array [
+        "ConditionalExpression",
+      ],
+    },
   ],
   "indent-legacy": "off",
   "jsx-a11y/alt-text": "warn",

--- a/packages/eslint-config-wantedly-typescript/index.js
+++ b/packages/eslint-config-wantedly-typescript/index.js
@@ -111,7 +111,7 @@ module.exports = {
     "valid-typeof": "error",
     camelcase: ["error", { ignoreDestructuring: false, properties: "never" }],
     eqeqeq: "warn",
-    indent: ["error", 2],
+    indent: ["error", 2, { ignoredNodes: ["ConditionalExpression"] }],
     quotes: ["off"],
     semi: ["error", "always"],
 

--- a/packages/eslint-config-wantedly-typescript/index.js
+++ b/packages/eslint-config-wantedly-typescript/index.js
@@ -111,7 +111,7 @@ module.exports = {
     "valid-typeof": "error",
     camelcase: ["error", { ignoreDestructuring: false, properties: "never" }],
     eqeqeq: "warn",
-    indent: ["error", 2, { ignoredNodes: ["ConditionalExpression"] }],
+    indent: ["error", 2, { SwitchCase: 1, ignoredNodes: ["ConditionalExpression"] }],
     quotes: ["off"],
     semi: ["error", "always"],
 


### PR DESCRIPTION
## WHY & WHAT

We use indent rule but we're using indented `case` in switch clause and ignoring ternary expression.