### PR TITLE
Use space-before-function-paren as always

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -1144,7 +1144,7 @@ Object {
     Object {
       "anonymous": "always",
       "asyncArrow": "always",
-      "named": "never",
+      "named": "always",
     },
   ],
   "space-before-function-parentheses": "off",

--- a/packages/eslint-config-wantedly-typescript/index.js
+++ b/packages/eslint-config-wantedly-typescript/index.js
@@ -106,7 +106,7 @@ module.exports = {
     "prefer-template": "warn",
     "quote-props": ["warn", "as-needed"],
     "require-yield": "error",
-    "space-before-function-paren": ["warn", { anonymous: "always", asyncArrow: "always", named: "never" }],
+    "space-before-function-paren": ["warn", { anonymous: "always", asyncArrow: "always", named: "always" }],
     "use-isnan": "error",
     "valid-typeof": "error",
     camelcase: ["error", { ignoreDestructuring: false, properties: "never" }],


### PR DESCRIPTION
## WHY & WHAT

We recommend to not add space between function and paren.
https://eslint.org/docs/rules/space-before-function-paren#always