### PR TITLE
Support branch option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,10 @@ commands:
             - node_modules
 
       - run:
+          name: Run Lint
+          command: yarn lint
+
+      - run:
           name: Run Test
           command: yarn test
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "test": "lerna run --parallel test",
-    "test:update": "lerna run --parallel test -- -u"
+    "test:update": "lerna run --parallel test -- -u",
+    "lint": "frolint --branch=master"
   }
 }

--- a/packages/frolint/preCommitHook.js
+++ b/packages/frolint/preCommitHook.js
@@ -30,8 +30,6 @@ function getFilesBetweenCurrentAndBranch(cwd, branch) {
   const { stdout: commitHash } = execa.shellSync(`git show-branch --merge-base ${branch} HEAD`, { cwd });
   const { stdout } = execa.shellSync(`git diff --name-only --diff-filter=ACMRTUB ${commitHash}`, { cwd });
 
-  console.log(stdout);
-
   return stdout.split("\n").filter(line => line.length > 0);
 }
 


### PR DESCRIPTION
## WHY & WHAT

If we want to lint in CI, we want the files only the PR included. So `frolint` supports branch option.

```sh-session
$ yarn frolint --branch=master
```