### PR TITLE
Add --no-stage option

### DIFF
--- a/packages/frolint/preCommitHook.js
+++ b/packages/frolint/preCommitHook.js
@@ -150,6 +150,7 @@ function parseArgs(args) {
     {
       "--formatter": String,
       "--branch": String,
+      "--no-stage": Boolean,
       "-v": "--formatter",
       "-b": "--branch",
     },
@@ -159,6 +160,7 @@ function parseArgs(args) {
   return {
     formatter: result["--formatter"],
     branch: result["--branch"],
+    noStage: result["--no-stage"],
   };
 }
 

--- a/packages/frolint/preCommitHook.js
+++ b/packages/frolint/preCommitHook.js
@@ -182,7 +182,8 @@ function hook(args, config) {
     const unstaged = getUnstagedFiles(rootDir);
     files = files.concat(Array.from(new Set([...staged, ...unstaged])));
     isFullyStaged = file => {
-      return !unstaged.includes(getRelativePath(rootDir, file));
+      const relativeFilepath = getRelativePath(rootDir, file);
+      return files.includes(relativeFilepath) && !unstaged.includes(relativeFilepath);
     };
   } else if (argResult.branch) {
     files = getFilesBetweenCurrentAndBranch(rootDir, argResult.branch);
@@ -205,7 +206,7 @@ function hook(args, config) {
     if (output) {
       fs.writeFileSync(filePath, output);
 
-      if (isFullyStaged(filePath)) {
+      if (!argResult.noStage && isFullyStaged(filePath)) {
         stageFile(getRelativePath(rootDir, filePath), rootDir);
       }
     }


### PR DESCRIPTION
## WHY & WHAT

If you want to run `frolint` but not want to stage files, you can use the `--no-stage` option.