### PR TITLE
Fix switch indent value to avoid conflict with Prettier's formatting.

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -852,7 +852,7 @@ Object {
     "error",
     2,
     Object {
-      "SwitchCase": 0,
+      "SwitchCase": 1,
       "flatTernaryExpressions": false,
       "ignoreComments": false,
       "ignoredNodes": Array [

--- a/packages/eslint-config-wantedly-typescript/index.js
+++ b/packages/eslint-config-wantedly-typescript/index.js
@@ -130,6 +130,7 @@ module.exports = {
       {
         flatTernaryExpressions: false,
         ignoredNodes: ["CallExpression", "ConditionalExpression", "LogicalExpression", "JSXElement"],
+        SwitchCase: 1,
       },
     ],
     "@typescript-eslint/no-unused-vars": [


### PR DESCRIPTION
## WHY

Prettier formats indents of a switch as following.

```
switch (t) {
case "a":
case "b":
default:
}
```

👇

```
switch (t) {
  case "a":
  case "b":
  default:
}
```

This conflicts with frolint indent rule.


## WHAT

- To avoid conflict with Prettier's formatting, fix "SwitchCase" option of "@typescript-eslint/indent"
- Update snap
