### PR TITLE
Upgrade ogh

### DIFF
--- a/packages/frolint/package.json
+++ b/packages/frolint/package.json
@@ -5,7 +5,7 @@
   "author": "Yuki Yamada <yamada@wantedly.com>",
   "bin": "index.js",
   "dependencies": {
-    "@yamadayuki/ogh": "^0.1.0",
+    "@yamadayuki/ogh": "^0.2.0",
     "arg": "^4.1.0",
     "chalk": "^2.4.2",
     "eslint": "^5.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -830,11 +830,12 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@yamadayuki/ogh@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@yamadayuki/ogh/-/ogh-0.1.0.tgz#04702f74a781f8d90cc3b48b23dedde9dfdbd897"
-  integrity sha512-z5vViifXocUWjq+Y2nAPRye4y9QlrLfFYNzkOMjI6hYxgOdxzMe/Ccpzzd9zBW1NgwsXiUDZQD/6mufH+mD5gQ==
+"@yamadayuki/ogh@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@yamadayuki/ogh/-/ogh-0.2.0.tgz#508dd062879ac23f1c7235c2850281e2a5e3b2e4"
+  integrity sha512-J4ORv0/qARBcvL/b3vAj1CCFBa89xRGIxO+XutinfRpvvqugio0UpYBtKob04Dv8ELD2JoWJXI1CWcrDJ9zn8A==
   dependencies:
+    command-exists "^1.2.8"
     cosmiconfig "^5.0.7"
 
 JSONStream@^1.0.4, JSONStream@^1.3.4:
@@ -1505,6 +1506,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
+
+command-exists@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
+  integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
 commander@^2.11.0:
   version "2.19.0"


### PR DESCRIPTION
## WHY & WHAT

`frolint` requires `git` command. But now the `@yamadayuki/ogh` package didn't consider the `git` command is not installed.
When we upgrade that package, it enables us to consider `git` command is not installed.