### PR TITLE
Set duplicate rules to off and specify the rules in @typescript-eslint

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -842,27 +842,19 @@ Object {
   "@typescript-eslint/adjacent-overload-signatures": "error",
   "@typescript-eslint/array-type": "error",
   "@typescript-eslint/ban-types": "error",
-  "@typescript-eslint/camelcase": "error",
+  "@typescript-eslint/camelcase": Array [
+    "error",
+    Object {
+      "ignoreDestructuring": true,
+      "properties": "never",
+    },
+  ],
   "@typescript-eslint/class-name-casing": "error",
   "@typescript-eslint/explicit-function-return-type": Array [
     "off",
   ],
   "@typescript-eslint/explicit-member-accessibility": "error",
-  "@typescript-eslint/indent": Array [
-    "error",
-    2,
-    Object {
-      "SwitchCase": 1,
-      "flatTernaryExpressions": false,
-      "ignoreComments": false,
-      "ignoredNodes": Array [
-        "CallExpression",
-        "ConditionalExpression",
-        "LogicalExpression",
-        "JSXElement",
-      ],
-    },
-  ],
+  "@typescript-eslint/indent": "off",
   "@typescript-eslint/interface-name-prefix": "error",
   "@typescript-eslint/member-delimiter-style": "off",
   "@typescript-eslint/no-angle-bracket-type-assertion": "error",
@@ -882,10 +874,12 @@ Object {
     "error",
     Object {
       "argsIgnorePattern": "^_",
+      "ignoreRestSiblings": true,
       "varsIgnorePattern": "^_",
     },
   ],
-  "@typescript-eslint/no-use-before-define": "error",
+  "@typescript-eslint/no-use-before-define": "off",
+  "@typescript-eslint/no-useless-constructor": "off",
   "@typescript-eslint/no-var-requires": "error",
   "@typescript-eslint/prefer-interface": "error",
   "@typescript-eslint/prefer-namespace-keyword": "error",
@@ -904,13 +898,7 @@ Object {
   "arrow-spacing": "off",
   "block-spacing": "off",
   "brace-style": "off",
-  "camelcase": Array [
-    "error",
-    Object {
-      "ignoreDestructuring": false,
-      "properties": "never",
-    },
-  ],
+  "camelcase": "off",
   "class-methods-use-this": "off",
   "comma-dangle": Array [
     "error",
@@ -982,7 +970,7 @@ Object {
   "new-parens": "off",
   "newline-per-chained-call": "off",
   "no-alert": "off",
-  "no-array-constructor": "error",
+  "no-array-constructor": "off",
   "no-arrow-condition": "off",
   "no-case-declarations": "error",
   "no-class-assign": "error",

--- a/packages/eslint-config-wantedly-typescript/index.js
+++ b/packages/eslint-config-wantedly-typescript/index.js
@@ -55,7 +55,7 @@ module.exports = {
     "max-len": ["off"],
     "new-cap": ["error", { capIsNew: false }],
     "no-alert": "off",
-    "no-array-constructor": "error",
+    "no-array-constructor": "off",
     "no-case-declarations": "error",
     "no-class-assign": "error",
     "no-compare-neg-zero": "error",
@@ -120,31 +120,24 @@ module.exports = {
     "space-before-function-paren": ["warn", { anonymous: "never", asyncArrow: "always", named: "never" }],
     "use-isnan": "error",
     "valid-typeof": "error",
-    camelcase: ["error", { ignoreDestructuring: false, properties: "never" }],
+    camelcase: "off",
     eqeqeq: "error",
     indent: "off",
     quotes: ["off"],
     semi: ["error", "always"],
 
     // @typescript-eslint/eslint-plugin rules
+    "@typescript-eslint/camelcase": ["error", { ignoreDestructuring: true, properties: "never" }],
     "@typescript-eslint/explicit-function-return-type": ["off"],
+    "@typescript-eslint/indent": "off",
+    "@typescript-eslint/no-array-constructor": "error",
     "@typescript-eslint/no-explicit-any": ["off"],
-    "@typescript-eslint/indent": [
-      "error",
-      2,
-      {
-        flatTernaryExpressions: false,
-        ignoredNodes: ["CallExpression", "ConditionalExpression", "LogicalExpression", "JSXElement"],
-        SwitchCase: 1,
-      },
-    ],
     "@typescript-eslint/no-unused-vars": [
       "error",
-      {
-        varsIgnorePattern: "^_",
-        argsIgnorePattern: "^_",
-      },
+      { varsIgnorePattern: "^_", argsIgnorePattern: "^_", ignoreRestSiblings: true },
     ],
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/no-useless-constructor": "off",
 
     // eslint-plugin-import rules
     "import/extensions": "off",


### PR DESCRIPTION
## WHY & WHAT

Set some rules properly because the `eslint` rules and `@typescript-eslint/eslint-plugin` rules conflict.