### PR TITLE
Export prettier config 

### DIFF
--- a/packages/frolint/README.md
+++ b/packages/frolint/README.md
@@ -94,6 +94,10 @@ No errors and warnings!
 ✨  Done in 2.36s.
 ```
 
+#### `frolint export`
+
+Export the `.prettierrc` config with default config in `frolint`.
+
 ## Configuration
 
 You can configure the `frolint` behaviour. `frolint` uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for configuration file support. We have not tested except the `package.json` but you can configure via below files.

--- a/packages/frolint/base.js
+++ b/packages/frolint/base.js
@@ -194,4 +194,5 @@ module.exports = {
   applyEslint,
   reportToConsole,
   applyPrettier,
+  SAMPLE_PRETTIER_CONFIG_FILE,
 };

--- a/packages/frolint/export.js
+++ b/packages/frolint/export.js
@@ -1,0 +1,19 @@
+const ogh = require("@yamadayuki/ogh");
+const fs = require("fs");
+const path = require("path");
+const { SAMPLE_PRETTIER_CONFIG_FILE } = require("./base");
+
+function exportPrettierConfig(args, _config) {
+  const rootDir = ogh.extractGitRootDirFromArgs(args);
+
+  const prettierConfig = fs.readFileSync(SAMPLE_PRETTIER_CONFIG_FILE).toString();
+  fs.writeFile(path.resolve(rootDir, ".prettierrc"), prettierConfig, err => {
+    if (err) {
+      console.error(err);
+    }
+  });
+}
+
+module.exports = {
+  exportPrettierConfig,
+};

--- a/packages/frolint/parseArgs.js
+++ b/packages/frolint/parseArgs.js
@@ -22,6 +22,7 @@ function parseArgs(args) {
     noStage: result["--no-stage"],
     help: result["--help"],
     noGit: result["--no-git"],
+    command: result._.slice(2, 3)[0],
   };
 }
 

--- a/packages/frolint/preCommitHook.js
+++ b/packages/frolint/preCommitHook.js
@@ -4,6 +4,7 @@ const { isInsideGitRepository } = require("./git");
 const { parseArgs, printHelp, printNoGitHelp } = require("./parseArgs");
 const { defaultImplementation } = require("./defaultImplementation");
 const { noGitImplementation } = require("./noGitImplementation");
+const { exportPrettierConfig } = require("./export");
 
 /**
  * @param {string[]} args process.argv
@@ -26,7 +27,7 @@ function hook(args, config) {
 
   switch (argResult.command) {
     case "export": {
-      console.log("export!!!");
+      exportPrettierConfig(args, config);
       break;
     }
     default: {

--- a/packages/frolint/preCommitHook.js
+++ b/packages/frolint/preCommitHook.js
@@ -24,10 +24,18 @@ function hook(args, config) {
     return;
   }
 
-  if (isGitRepo) {
-    defaultImplementation(args, config);
-  } else {
-    noGitImplementation(args, config);
+  switch (argResult.command) {
+    case "export": {
+      console.log("export!!!");
+      break;
+    }
+    default: {
+      if (isGitRepo) {
+        defaultImplementation(args, config);
+      } else {
+        noGitImplementation(args, config);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## WHY & WHAT

Some editor respect the `.prettierrc` file in the project root. So the `frolint` should export `.prettierrc` file.