### PR TITLE
Consider ignorePath for ESLint and Prettier

### DIFF
--- a/packages/frolint/base.js
+++ b/packages/frolint/base.js
@@ -152,12 +152,12 @@ function isPrettierSupported(file) {
   return supportedExtensions.includes(path.extname(file));
 }
 
-function getInferredParser(file) {
-  return prettier.getFileInfo.sync(file).inferredParser;
+function getInferredParser(file, prettierConfig = {}) {
+  return prettier.getFileInfo.sync(file, { ignorePath: prettierConfig.ignorePath }).inferredParser;
 }
 
-function isIgnoredForPrettier(file) {
-  return prettier.getFileInfo.sync(file).ignored;
+function isIgnoredForPrettier(file, prettierConfig = {}) {
+  return prettier.getFileInfo.sync(file, { ignorePath: prettierConfig.ignorePath }).ignored;
 }
 
 function applyPrettier(args, config, files) {
@@ -165,8 +165,8 @@ function applyPrettier(args, config, files) {
   const { prettierConfig } = optionsFromConfig(config);
 
   return files
-    .filter(isPrettierSupported)
-    .filter(isIgnoredForPrettier)
+    .filter(file => isPrettierSupported(file, prettierConfig))
+    .filter(file => isIgnoredForPrettier(file, prettierConfig))
     .map(file => {
       const filePath = path.resolve(rootDir, file);
       const prettierOption = prettier.resolveConfig.sync(filePath, {

--- a/packages/frolint/base.js
+++ b/packages/frolint/base.js
@@ -166,7 +166,7 @@ function applyPrettier(args, config, files) {
 
   return files
     .filter(file => isPrettierSupported(file, prettierConfig))
-    .filter(file => isIgnoredForPrettier(file, prettierConfig))
+    .filter(file => !isIgnoredForPrettier(file, prettierConfig))
     .map(file => {
       const filePath = path.resolve(rootDir, file);
       const prettierOption = prettier.resolveConfig.sync(filePath, {

--- a/packages/frolint/base.js
+++ b/packages/frolint/base.js
@@ -65,8 +65,9 @@ function getCli(cwd, eslintConfigPackage = "eslint-config-wantedly-typescript", 
 
 function applyEslint(args, files, eslintConfigPackage, eslintConfig) {
   const rootDir = ogh.extractGitRootDirFromArgs(args);
+  const cli = getCli(rootDir, eslintConfigPackage, eslintConfig);
 
-  return getCli(rootDir, eslintConfigPackage, eslintConfig).executeOnFiles(files.filter(isSupportedExtension));
+  return cli.executeOnFiles(files.filter(isSupportedExtension).filter(file => !cli.isPathIgnored(file)));
 }
 
 function reportNoop() {

--- a/packages/frolint/base.js
+++ b/packages/frolint/base.js
@@ -156,12 +156,17 @@ function getInferredParser(file) {
   return prettier.getFileInfo.sync(file).inferredParser;
 }
 
+function isIgnoredForPrettier(file) {
+  return prettier.getFileInfo.sync(file).ignored;
+}
+
 function applyPrettier(args, config, files) {
   const rootDir = ogh.extractGitRootDirFromArgs(args);
   const { prettierConfig } = optionsFromConfig(config);
 
   return files
-    .filter(file => isPrettierSupported(file))
+    .filter(isPrettierSupported)
+    .filter(isIgnoredForPrettier)
     .map(file => {
       const filePath = path.resolve(rootDir, file);
       const prettierOption = prettier.resolveConfig.sync(filePath, {

--- a/packages/frolint/base.js
+++ b/packages/frolint/base.js
@@ -35,7 +35,7 @@ function detectReactVersion(cwd) {
  * ESLint utilities
  */
 
-function getCli(cwd, eslintConfigPackage) {
+function getCli(cwd, eslintConfigPackage = "eslint-config-wantedly-typescript", eslintConfig = {}) {
   const reactVersion = detectReactVersion(cwd);
   const isReact = !!reactVersion;
   const netEslintConfigPackage = eslintConfigPackage.replace("eslint-config-", "") + (isReact ? "" : "/without-react");
@@ -57,15 +57,16 @@ function getCli(cwd, eslintConfigPackage) {
     },
     fix: true,
     cwd,
+    ignorePath: eslintConfig.ignorePath,
   });
 
   return cli;
 }
 
-function applyEslint(args, files, eslintConfigPackage) {
+function applyEslint(args, files, eslintConfigPackage, eslintConfig) {
   const rootDir = ogh.extractGitRootDirFromArgs(args);
 
-  return getCli(rootDir, eslintConfigPackage).executeOnFiles(files.filter(isSupportedExtension));
+  return getCli(rootDir, eslintConfigPackage, eslintConfig).executeOnFiles(files.filter(isSupportedExtension));
 }
 
 function reportNoop() {

--- a/packages/frolint/config.js
+++ b/packages/frolint/config.js
@@ -4,18 +4,20 @@
  * @property {boolean} typescript - Indicates whether the eslint config uses @typescript-eslint or not.
  * @property {string} [formatter] - Indicates the formatter for console
  * @property {Object} prettierConfig - Indicates the prettier option
+ * @property {Object} eslintConfig - Indicates the prettier option
  */
 
 /**
  * @param {...Froconf} config a config of froconf
  */
 function optionsFromConfig(config) {
-  const { typescript, formatter, prettier } = config;
+  const { typescript, formatter, prettier, eslint } = config;
 
   return {
     isTypescript: typeof typescript === "boolean" ? typescript : true,
     formatter,
     prettierConfig: prettier,
+    eslintConfig: eslint,
   };
 }
 

--- a/packages/frolint/defaultImplementation.js
+++ b/packages/frolint/defaultImplementation.js
@@ -10,7 +10,7 @@ const { parseArgs } = require("./parseArgs");
 function defaultImplementation(args, config) {
   const rootDir = ogh.extractGitRootDirFromArgs(args);
   const argResult = parseArgs(args);
-  const { isTypescript, formatter } = optionsFromConfig(config);
+  const { isTypescript, formatter, eslintConfig } = optionsFromConfig(config);
   const isPreCommit = ogh.extractHookFromArgs(args) === "pre-commit";
 
   let files = [];
@@ -43,7 +43,7 @@ function defaultImplementation(args, config) {
   /**
    * Apply ESLint step
    */
-  const report = applyEslint(args, files, eslintConfigPackage);
+  const report = applyEslint(args, files, eslintConfigPackage, eslintConfig);
   report.results.forEach(result => {
     const { filePath, output } = result;
     if (output) {


### PR DESCRIPTION
## WHY & WHAT

Fix https://github.com/wantedly/frolint/issues/36

Enable to consider `.eslintignore` and `.prettierignore`. Both eslint and prettier couldn't consider the ignore files implicitly. It is correct and we should consider the paths explicitly.