### PR TITLE
Use explicit-member-accessibility with no-public option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["wantedly-typescript"],
+  "extends": ["wantedly-typescript/without-react"],
   "rules": {
     "no-console": "off",
     "@typescript-eslint/no-var-requires": "off"

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["wantedly/without-react"],
+  "extends": ["wantedly-typescript"],
   "rules": {
     "no-console": "off",
     "@typescript-eslint/no-var-requires": "off"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "packages/*"
   ],
   "frolint": {
-    "typescript": false,
     "prettier": {
       "config": "./.prettierrc"
     }

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -853,7 +853,12 @@ Object {
   "@typescript-eslint/explicit-function-return-type": Array [
     "off",
   ],
-  "@typescript-eslint/explicit-member-accessibility": "error",
+  "@typescript-eslint/explicit-member-accessibility": Array [
+    "error",
+    Object {
+      "accessibility": "no-public",
+    },
+  ],
   "@typescript-eslint/indent": "off",
   "@typescript-eslint/interface-name-prefix": "error",
   "@typescript-eslint/member-delimiter-style": "off",

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -856,7 +856,11 @@ Object {
   "@typescript-eslint/explicit-member-accessibility": Array [
     "error",
     Object {
-      "accessibility": "no-public",
+      "overrides": Object {
+        "accessors": "no-public",
+        "constructors": "no-public",
+        "parameterProperties": "no-public",
+      },
     },
   ],
   "@typescript-eslint/indent": "off",

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
@@ -851,7 +851,12 @@ Object {
   "@typescript-eslint/explicit-function-return-type": Array [
     "off",
   ],
-  "@typescript-eslint/explicit-member-accessibility": "error",
+  "@typescript-eslint/explicit-member-accessibility": Array [
+    "error",
+    Object {
+      "accessibility": "no-public",
+    },
+  ],
   "@typescript-eslint/indent": "off",
   "@typescript-eslint/interface-name-prefix": "error",
   "@typescript-eslint/member-delimiter-style": "off",

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
@@ -854,7 +854,11 @@ Object {
   "@typescript-eslint/explicit-member-accessibility": Array [
     "error",
     Object {
-      "accessibility": "no-public",
+      "overrides": Object {
+        "accessors": "no-public",
+        "constructors": "no-public",
+        "parameterProperties": "no-public",
+      },
     },
   ],
   "@typescript-eslint/indent": "off",

--- a/packages/eslint-config-wantedly-typescript/fixtures/@typescript-eslint/explicit-member-accessibility/index.ts
+++ b/packages/eslint-config-wantedly-typescript/fixtures/@typescript-eslint/explicit-member-accessibility/index.ts
@@ -5,7 +5,7 @@ class Animal {
     // Parameter property and constructor
     this.animalName = name;
   }
-  animalName: string; // Property
+  public animalName: string; // Property
   get name(): string {
     // get accessor
     return this.animalName;
@@ -14,7 +14,7 @@ class Animal {
     // set accessor
     this.animalName = value;
   }
-  walk() {
+  public walk() {
     // method
   }
 }

--- a/packages/eslint-config-wantedly-typescript/fixtures/@typescript-eslint/explicit-member-accessibility/index.ts
+++ b/packages/eslint-config-wantedly-typescript/fixtures/@typescript-eslint/explicit-member-accessibility/index.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+class Animal {
+  constructor(name: string) {
+    // Parameter property and constructor
+    this.animalName = name;
+  }
+  animalName: string; // Property
+  get name(): string {
+    // get accessor
+    return this.animalName;
+  }
+  set name(value: string) {
+    // set accessor
+    this.animalName = value;
+  }
+  walk() {
+    // method
+  }
+}

--- a/packages/eslint-config-wantedly-typescript/without-react.js
+++ b/packages/eslint-config-wantedly-typescript/without-react.js
@@ -119,7 +119,16 @@ module.exports = {
     // @typescript-eslint/eslint-plugin rules
     "@typescript-eslint/camelcase": ["error", { ignoreDestructuring: true, properties: "never" }],
     "@typescript-eslint/explicit-function-return-type": ["off"],
-    "@typescript-eslint/explicit-member-accessibility": ["error", { accessibility: "no-public" }],
+    "@typescript-eslint/explicit-member-accessibility": [
+      "error",
+      {
+        overrides: {
+          constructors: "no-public",
+          parameterProperties: "no-public",
+          accessors: "no-public",
+        },
+      },
+    ],
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/no-array-constructor": "error",
     "@typescript-eslint/no-explicit-any": ["off"],

--- a/packages/eslint-config-wantedly-typescript/without-react.js
+++ b/packages/eslint-config-wantedly-typescript/without-react.js
@@ -119,6 +119,7 @@ module.exports = {
     // @typescript-eslint/eslint-plugin rules
     "@typescript-eslint/camelcase": ["error", { ignoreDestructuring: true, properties: "never" }],
     "@typescript-eslint/explicit-function-return-type": ["off"],
+    "@typescript-eslint/explicit-member-accessibility": ["error", { accessibility: "no-public" }],
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/no-array-constructor": "error",
     "@typescript-eslint/no-explicit-any": ["off"],


### PR DESCRIPTION
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md

Introduce `explicit-member-accessibility`'s options.

```js
"@typescript-eslint/explicit-member-accessibility": [
  "error",
  {
    overrides: {
      constructors: "no-public",
      parameterProperties: "no-public",
      accessors: "no-public",
    },
  },
],
```

`constructor, parameter properties, accessors` are almost defined as public. `method, properties` should be defined as public/private with developers consideration appropriately.