### PR TITLE
Introduce eslint-plugin-react-hooks rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,10 @@
 {
-  "extends": ["wantedly-typescript/without-react"],
+  "extends": ["wantedly-typescript"],
+  "settings": {
+    "react": {
+      "version": "latest"
+    }
+  },
   "rules": {
     "no-console": "off",
     "@typescript-eslint/no-var-requires": "off"

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -1094,6 +1094,8 @@ Object {
   "quotes": Array [
     "off",
   ],
+  "react-hooks/exhaustive-deps": "warn",
+  "react-hooks/rules-of-hooks": "error",
   "react/display-name": 2,
   "react/forbid-prop-types": "off",
   "react/jsx-closing-bracket-location": "warn",

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -834,6 +834,7 @@ Array [
   "jsx-a11y",
   "jest",
   "prettier",
+  "react-hooks",
 ]
 `;
 

--- a/packages/eslint-config-wantedly-typescript/index.js
+++ b/packages/eslint-config-wantedly-typescript/index.js
@@ -29,5 +29,9 @@ module.exports = {
     "react/no-unused-prop-types": "off",
     "react/prop-types": "off",
     "react/require-default-props": "off",
+
+    // eslint-plugin-react-hooks rules
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
   },
 };

--- a/packages/eslint-config-wantedly-typescript/index.js
+++ b/packages/eslint-config-wantedly-typescript/index.js
@@ -6,7 +6,7 @@ module.exports = {
   extends: [...extendOptions, "plugin:react/recommended"],
   parser,
   parserOptions,
-  plugins: [...plugins, "react"],
+  plugins: [...plugins, "react", "react-hooks"],
   rules: {
     ...rules,
 

--- a/packages/eslint-config-wantedly-typescript/package.json
+++ b/packages/eslint-config-wantedly-typescript/package.json
@@ -13,6 +13,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^1.6.0",
     "typescript": "^3.3.4000"
   },
   "homepage": "https://github.com/wantedly/frolint",

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -1166,6 +1166,8 @@ Object {
     "off",
   ],
   "radix": "off",
+  "react-hooks/exhaustive-deps": "warn",
+  "react-hooks/rules-of-hooks": "error",
   "react/display-name": 2,
   "react/forbid-prop-types": "off",
   "react/jsx-closing-bracket-location": "warn",

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -832,6 +832,7 @@ Array [
   "jsx-a11y",
   "jest",
   "prettier",
+  "react-hooks",
 ]
 `;
 

--- a/packages/eslint-config-wantedly/index.js
+++ b/packages/eslint-config-wantedly/index.js
@@ -29,5 +29,9 @@ module.exports = {
     "react/no-unused-prop-types": "off",
     "react/prop-types": "off",
     "react/require-default-props": "off",
+
+    // eslint-plugin-react-hooks rules
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
   },
 };

--- a/packages/eslint-config-wantedly/index.js
+++ b/packages/eslint-config-wantedly/index.js
@@ -6,7 +6,7 @@ module.exports = {
   extends: [...extendOptions, "plugin:react/recommended"],
   parser,
   parserOptions,
-  plugins: [...plugins, "react"],
+  plugins: [...plugins, "react", "react-hooks"],
   rules: {
     ...rules,
 

--- a/packages/eslint-config-wantedly/package.json
+++ b/packages/eslint-config-wantedly/package.json
@@ -11,7 +11,8 @@
     "eslint-plugin-jest": "^22.4.1",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-react": "^7.12.4"
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^1.6.0"
   },
   "homepage": "https://github.com/wantedly/frolint",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2370,6 +2370,11 @@ eslint-plugin-prettier@^3.0.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+
 eslint-plugin-react@^7.12.4:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"


### PR DESCRIPTION
To close https://github.com/wantedly/frolint/issues/59

Introduce `eslint-plugin-react-hooks`.
c.f. https://reactjs.org/docs/hooks-rules.html#eslint-plugin