### PR TITLE
Create eslint-plugin-use-macros

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -834,6 +834,7 @@ Array [
   "jsx-a11y",
   "jest",
   "prettier",
+  "use-macros",
   "react-hooks",
 ]
 `;
@@ -1190,6 +1191,8 @@ Object {
   "template-tag-spacing": "off",
   "unicode-bom": "off",
   "use-isnan": "error",
+  "use-macros/graphql-tag": "error",
+  "use-macros/styled-components": "error",
   "valid-typeof": "error",
   "wrap-iife": "off",
   "wrap-regex": "off",

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
@@ -832,6 +832,7 @@ Array [
   "jsx-a11y",
   "jest",
   "prettier",
+  "use-macros",
 ]
 `;
 
@@ -1128,6 +1129,7 @@ Object {
   "template-tag-spacing": "off",
   "unicode-bom": "off",
   "use-isnan": "error",
+  "use-macros/graphql-tag": "error",
   "valid-typeof": "error",
   "wrap-iife": "off",
   "wrap-regex": "off",

--- a/packages/eslint-config-wantedly-typescript/fixtures/use-macros/graphql-tag/index.ts
+++ b/packages/eslint-config-wantedly-typescript/fixtures/use-macros/graphql-tag/index.ts
@@ -1,4 +1,4 @@
-import gql from "graphql-tag.macro";
+import { gql } from "graphql.macro";
 
 const _QUERY = gql`
   query getProject {

--- a/packages/eslint-config-wantedly-typescript/fixtures/use-macros/graphql-tag/index.ts
+++ b/packages/eslint-config-wantedly-typescript/fixtures/use-macros/graphql-tag/index.ts
@@ -1,0 +1,8 @@
+import gql from "graphql-tag.macro";
+
+const _QUERY = gql`
+  query getProject {
+    id
+    title
+  }
+`;

--- a/packages/eslint-config-wantedly-typescript/fixtures/use-macros/styled-components/index.ts
+++ b/packages/eslint-config-wantedly-typescript/fixtures/use-macros/styled-components/index.ts
@@ -1,0 +1,6 @@
+import styled from "styled-components/macro";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const Button = styled.button`
+  border: 1px solid blue;
+`;

--- a/packages/eslint-config-wantedly-typescript/index.js
+++ b/packages/eslint-config-wantedly-typescript/index.js
@@ -33,5 +33,8 @@ module.exports = {
     // eslint-plugin-react-hooks rules
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
+
+    // eslint-plugin-use-macros rules
+    "use-macros/styled-components": "error",
   },
 };

--- a/packages/eslint-config-wantedly-typescript/package.json
+++ b/packages/eslint-config-wantedly-typescript/package.json
@@ -14,6 +14,7 @@
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^1.6.0",
+    "eslint-plugin-use-macros": "^0.5.2",
     "typescript": "^3.3.4000"
   },
   "homepage": "https://github.com/wantedly/frolint",

--- a/packages/eslint-config-wantedly-typescript/without-react.js
+++ b/packages/eslint-config-wantedly-typescript/without-react.js
@@ -17,7 +17,7 @@ module.exports = {
     },
     sourceType: "module",
   },
-  plugins: ["import", "jsx-a11y", "jest", "prettier", "@typescript-eslint"],
+  plugins: ["import", "jsx-a11y", "jest", "prettier", "@typescript-eslint", "use-macros"],
   rules: {
     "array-callback-return": "off",
     "arrow-body-style": ["off"],
@@ -147,5 +147,8 @@ module.exports = {
     "jsx-a11y/label-has-for": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "jsx-a11y/no-static-element-interactions": "off",
+
+    // eslint-plugin-use-macros rules
+    "use-macros/graphql-tag": "error",
   },
 };

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -832,6 +832,7 @@ Array [
   "jsx-a11y",
   "jest",
   "prettier",
+  "use-macros",
   "react-hooks",
 ]
 `;
@@ -1267,6 +1268,8 @@ Object {
   "template-tag-spacing": "off",
   "unicode-bom": "off",
   "use-isnan": "error",
+  "use-macros/graphql-tag": "error",
+  "use-macros/styled-components": "error",
   "valid-jsdoc": "off",
   "valid-typeof": "error",
   "vars-on-top": "off",

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
@@ -830,6 +830,7 @@ Array [
   "jsx-a11y",
   "jest",
   "prettier",
+  "use-macros",
 ]
 `;
 
@@ -1205,6 +1206,7 @@ Object {
   "template-tag-spacing": "off",
   "unicode-bom": "off",
   "use-isnan": "error",
+  "use-macros/graphql-tag": "error",
   "valid-jsdoc": "off",
   "valid-typeof": "error",
   "vars-on-top": "off",

--- a/packages/eslint-config-wantedly/index.js
+++ b/packages/eslint-config-wantedly/index.js
@@ -33,5 +33,8 @@ module.exports = {
     // eslint-plugin-react-hooks rules
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
+
+    // eslint-plugin-use-macros rules
+    "use-macros/styled-components": "error",
   },
 };

--- a/packages/eslint-config-wantedly/package.json
+++ b/packages/eslint-config-wantedly/package.json
@@ -12,7 +12,8 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.4",
-    "eslint-plugin-react-hooks": "^1.6.0"
+    "eslint-plugin-react-hooks": "^1.6.0",
+    "eslint-plugin-use-macros": "^0.5.2"
   },
   "homepage": "https://github.com/wantedly/frolint",
   "keywords": [

--- a/packages/eslint-config-wantedly/without-react.js
+++ b/packages/eslint-config-wantedly/without-react.js
@@ -17,7 +17,7 @@ module.exports = {
     },
     sourceType: "module",
   },
-  plugins: ["import", "jsx-a11y", "jest", "prettier"],
+  plugins: ["import", "jsx-a11y", "jest", "prettier", "use-macros"],
   rules: {
     "array-callback-return": "off",
     "arrow-body-style": ["off"],
@@ -135,5 +135,8 @@ module.exports = {
     "jsx-a11y/label-has-for": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "jsx-a11y/no-static-element-interactions": "off",
+
+    // eslint-plugin-use-macros rules
+    "use-macros/graphql-tag": "error",
   },
 };

--- a/packages/eslint-plugin-use-macros/README.md
+++ b/packages/eslint-plugin-use-macros/README.md
@@ -1,0 +1,9 @@
+# eslint-plugin-use-macros [![npm version](https://badge.fury.io/js/eslint-plugin-use-macros.svg)](https://badge.fury.io/js/eslint-plugin-use-macros)
+
+## Installation
+
+```sh
+npm install --save eslint-plugin-use-macros
+# or
+yarn add eslint-plugin-use-macros
+```

--- a/packages/eslint-plugin-use-macros/__tests__/GraphQLTag.js
+++ b/packages/eslint-plugin-use-macros/__tests__/GraphQLTag.js
@@ -1,0 +1,24 @@
+const RuleTester = require("eslint").RuleTester;
+const ESLintConfigWantedly = require("eslint-config-wantedly/without-react");
+const GraphQLTagRule = require("../rules/GraphQLTag");
+
+RuleTester.setDefaultConfig({
+  parser: ESLintConfigWantedly.parser,
+  parserOptions: ESLintConfigWantedly.parserOptions,
+});
+
+const ruleTester = new RuleTester();
+ruleTester.run("use-macros/graphql-tag", GraphQLTagRule, {
+  valid: [
+    {
+      code: `import gql from "graphql-tag.macro";`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import styled from "graphql-tag";`,
+      output: `import styled from "graphql-tag.macro";`,
+      errors: ['Please import from "graphql-tag.macro" instead of "graphql-tag"'],
+    },
+  ],
+});

--- a/packages/eslint-plugin-use-macros/__tests__/GraphQLTag.test.js
+++ b/packages/eslint-plugin-use-macros/__tests__/GraphQLTag.test.js
@@ -11,14 +11,14 @@ const ruleTester = new RuleTester();
 ruleTester.run("use-macros/graphql-tag", GraphQLTagRule, {
   valid: [
     {
-      code: `import gql from "graphql-tag.macro";`,
+      code: `import { gql } from "graphql.macro";`,
     },
   ],
   invalid: [
     {
-      code: `import styled from "graphql-tag";`,
-      output: `import styled from "graphql-tag.macro";`,
-      errors: ['Please import from "graphql-tag.macro" instead of "graphql-tag"'],
+      code: `import gql from "graphql-tag";`,
+      output: `import { gql } from "graphql.macro";`,
+      errors: ['Please import from "graphql.macro" instead of "graphql-tag"'],
     },
   ],
 });

--- a/packages/eslint-plugin-use-macros/__tests__/StyledComponents.test.js
+++ b/packages/eslint-plugin-use-macros/__tests__/StyledComponents.test.js
@@ -1,0 +1,24 @@
+const RuleTester = require("eslint").RuleTester;
+const ESLintConfigWantedly = require("eslint-config-wantedly/without-react");
+const StyledComponentsRule = require("../rules/StyledComponents");
+
+RuleTester.setDefaultConfig({
+  parser: ESLintConfigWantedly.parser,
+  parserOptions: ESLintConfigWantedly.parserOptions,
+});
+
+const ruleTester = new RuleTester();
+ruleTester.run("use-macros/styled-components", StyledComponentsRule, {
+  valid: [
+    {
+      code: `import styled from "styled-components/macro";`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import styled from "styled-components";`,
+      output: `import styled from "styled-components/macro";`,
+      errors: ['Please import from "styled-components/macro" instead of "styled-components"'],
+    },
+  ],
+});

--- a/packages/eslint-plugin-use-macros/createUseMacro.js
+++ b/packages/eslint-plugin-use-macros/createUseMacro.js
@@ -1,25 +1,23 @@
 module.exports = function createUseMacro(from, to, context) {
-  function checkBabelPluginMacroInstalled() {
-    try {
-      require.resolve("babel-plugin-macros");
-      return true;
-    } catch (_err) {
-      return false;
-    }
+  let BABEL_PLUGIN_MACROS_INSTALLED = false;
+  let TARGET_LIBRARY_INSTALLED = false;
+
+  try {
+    require.resolve("babel-plugin-macros");
+    BABEL_PLUGIN_MACROS_INSTALLED = true;
+  } catch (_err) {
+    BABEL_PLUGIN_MACROS_INSTALLED = false;
   }
 
-  function checkPackageExists() {
-    try {
-      require.resolve(from);
-      require.resolve(to);
-      return true;
-    } catch (_err) {
-      return false;
-    }
+  try {
+    require.resolve(to);
+    TARGET_LIBRARY_INSTALLED = true;
+  } catch (_err) {
+    TARGET_LIBRARY_INSTALLED = false;
   }
 
   return function(node) {
-    if (!checkBabelPluginMacroInstalled()) {
+    if (!BABEL_PLUGIN_MACROS_INSTALLED) {
       context.report({
         node,
         message: "Please install 'babel-plugin-macro' to use macro",
@@ -30,7 +28,7 @@ module.exports = function createUseMacro(from, to, context) {
     const importName = node.source.value.trim();
 
     if (importName === from) {
-      if (!checkPackageExists()) {
+      if (!TARGET_LIBRARY_INSTALLED) {
         context.report({
           node,
           message: "Please install {{to}} to use macro",

--- a/packages/eslint-plugin-use-macros/createUseMacro.js
+++ b/packages/eslint-plugin-use-macros/createUseMacro.js
@@ -1,0 +1,55 @@
+module.exports = function createUseMacro(from, to, context) {
+  function checkBabelPluginMacroInstalled() {
+    try {
+      require.resolve("babel-plugin-macros");
+      return true;
+    } catch (_err) {
+      return false;
+    }
+  }
+
+  function checkPackageExists() {
+    try {
+      require.resolve(from);
+      require.resolve(to);
+      return true;
+    } catch (_err) {
+      return false;
+    }
+  }
+
+  return function(node) {
+    if (!checkBabelPluginMacroInstalled()) {
+      context.report({
+        node,
+        message: "Please install 'babel-plugin-macro' to use macro",
+      });
+      return;
+    }
+
+    const importName = node.source.value.trim();
+
+    if (importName === from) {
+      if (!checkPackageExists()) {
+        context.report({
+          node,
+          message: "Please install {{to}} to use macro",
+          data: {
+            to,
+          },
+        });
+        return;
+      }
+
+      const [start, end] = node.source.range;
+      context.report({
+        node,
+        message: 'Please import from "{{to}}" instead of "{{from}}"',
+        data: { from, to },
+        fix(fixer) {
+          return fixer.replaceTextRange([start + 1, end - 1], to);
+        },
+      });
+    }
+  };
+};

--- a/packages/eslint-plugin-use-macros/index.js
+++ b/packages/eslint-plugin-use-macros/index.js
@@ -1,0 +1,7 @@
+const StyledComponents = require("./rules/StyledComponents");
+
+module.exports = {
+  rules: {
+    "styled-components": StyledComponents,
+  },
+};

--- a/packages/eslint-plugin-use-macros/index.js
+++ b/packages/eslint-plugin-use-macros/index.js
@@ -1,7 +1,9 @@
+const GraphQLTag = require("./rules/GraphQLTag");
 const StyledComponents = require("./rules/StyledComponents");
 
 module.exports = {
   rules: {
+    "graphql-tag": GraphQLTag,
     "styled-components": StyledComponents,
   },
 };

--- a/packages/eslint-plugin-use-macros/package.json
+++ b/packages/eslint-plugin-use-macros/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "eslint-plugin-use-macros",
+  "description": "ESLint rules for libraries which supports the babel-macros",
+  "version": "0.5.2",
+  "author": "Yuki Yamada <yamada@wantedly.com>",
+  "homepage": "https://github.com/wantedly/frolint",
+  "keywords": [
+    "eslint",
+    "eslint-plugin",
+    "eslintplugin"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-use-macros",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "babel-plugin-macros": "^2.5.1",
+    "eslint": "^5.16.0",
+    "eslint-config-wantedly": "^0.5.2",
+    "styled-components": "^4.2.0"
+  }
+}

--- a/packages/eslint-plugin-use-macros/package.json
+++ b/packages/eslint-plugin-use-macros/package.json
@@ -23,7 +23,7 @@
     "eslint": "^5.16.0",
     "eslint-config-wantedly": "^0.5.2",
     "graphql-tag": "^2.10.1",
-    "graphql-tag.macro": "^2.1.0",
+    "graphql.macro": "^1.4.2",
     "styled-components": "^4.2.0"
   }
 }

--- a/packages/eslint-plugin-use-macros/package.json
+++ b/packages/eslint-plugin-use-macros/package.json
@@ -22,6 +22,8 @@
     "babel-plugin-macros": "^2.5.1",
     "eslint": "^5.16.0",
     "eslint-config-wantedly": "^0.5.2",
+    "graphql-tag": "^2.10.1",
+    "graphql-tag.macro": "^2.1.0",
     "styled-components": "^4.2.0"
   }
 }

--- a/packages/eslint-plugin-use-macros/rules/GraphQLTag.js
+++ b/packages/eslint-plugin-use-macros/rules/GraphQLTag.js
@@ -1,23 +1,21 @@
 const FROM = "graphql-tag";
 const TO = "graphql.macro";
 
-function checkBabelPluginMacroInstalled() {
-  try {
-    require.resolve("babel-plugin-macros");
-    return true;
-  } catch (_err) {
-    return false;
-  }
+let BABEL_PLUGIN_MACROS_INSTALLED = false;
+let GRAPHQL_MACRO_INSTALLED = false;
+
+try {
+  require.resolve("babel-plugin-macros");
+  BABEL_PLUGIN_MACROS_INSTALLED = true;
+} catch (_err) {
+  BABEL_PLUGIN_MACROS_INSTALLED = false;
 }
 
-function checkPackageExists() {
-  try {
-    require.resolve(FROM);
-    require.resolve(TO);
-    return true;
-  } catch (_err) {
-    return false;
-  }
+try {
+  require.resolve(TO);
+  GRAPHQL_MACRO_INSTALLED = true;
+} catch (_err) {
+  GRAPHQL_MACRO_INSTALLED = false;
 }
 
 module.exports = {
@@ -28,7 +26,7 @@ module.exports = {
   create(context) {
     return {
       ImportDeclaration(node) {
-        if (!checkBabelPluginMacroInstalled()) {
+        if (!BABEL_PLUGIN_MACROS_INSTALLED) {
           context.report({
             node,
             message: 'Please install "babel-plugin-macro" to use macro',
@@ -39,7 +37,7 @@ module.exports = {
         const importName = node.source.value.trim();
 
         if (importName === FROM) {
-          if (!checkPackageExists()) {
+          if (!GRAPHQL_MACRO_INSTALLED) {
             context.report({
               node,
               message: 'Please install "graphql.macro" to use macro',

--- a/packages/eslint-plugin-use-macros/rules/GraphQLTag.js
+++ b/packages/eslint-plugin-use-macros/rules/GraphQLTag.js
@@ -1,4 +1,24 @@
-const createUseMacro = require("../createUseMacro");
+const FROM = "graphql-tag";
+const TO = "graphql.macro";
+
+function checkBabelPluginMacroInstalled() {
+  try {
+    require.resolve("babel-plugin-macros");
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
+
+function checkPackageExists() {
+  try {
+    require.resolve(FROM);
+    require.resolve(TO);
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
 
 module.exports = {
   meta: {
@@ -7,7 +27,40 @@ module.exports = {
   },
   create(context) {
     return {
-      ImportDeclaration: createUseMacro("graphql-tag", "graphql-tag.macro", context),
+      ImportDeclaration(node) {
+        if (!checkBabelPluginMacroInstalled()) {
+          context.report({
+            node,
+            message: 'Please install "babel-plugin-macro" to use macro',
+          });
+          return;
+        }
+
+        const importName = node.source.value.trim();
+
+        if (importName === FROM) {
+          if (!checkPackageExists()) {
+            context.report({
+              node,
+              message: 'Please install "graphql.macro" to use macro',
+            });
+            return;
+          }
+
+          const specifier = node.specifiers[0];
+          const [start, end] = node.source.range;
+          context.report({
+            node,
+            message: 'Please import from "graphql.macro" instead of "graphql-tag"',
+            fix(fixer) {
+              return [
+                fixer.replaceTextRange(specifier.range, "{ gql }"),
+                fixer.replaceTextRange([start + 1, end - 1], TO),
+              ];
+            },
+          });
+        }
+      },
     };
   },
 };

--- a/packages/eslint-plugin-use-macros/rules/GraphQLTag.js
+++ b/packages/eslint-plugin-use-macros/rules/GraphQLTag.js
@@ -1,0 +1,13 @@
+const createUseMacro = require("../createUseMacro");
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+  },
+  create(context) {
+    return {
+      ImportDeclaration: createUseMacro("graphql-tag", "graphql-tag.macro", context),
+    };
+  },
+};

--- a/packages/eslint-plugin-use-macros/rules/StyledComponents.js
+++ b/packages/eslint-plugin-use-macros/rules/StyledComponents.js
@@ -1,0 +1,13 @@
+const createUseMacro = require("../createUseMacro");
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+  },
+  create(context) {
+    return {
+      ImportDeclaration: createUseMacro("styled-components", "styled-components/macro", context),
+    };
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,7 +128,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
   integrity sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==
 
-"@babel/parser@^7.1.6", "@babel/parser@^7.4.5":
+"@babel/parser@^7.1.6", "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
   version "7.4.5"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
   integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
@@ -155,6 +155,15 @@
     "@babel/code-frame" "^7.0.0"
     "@babel/parser" "^7.2.2"
     "@babel/types" "^7.2.2"
+
+"@babel/template@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
+  integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
 
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.2.2":
   version "7.2.3"
@@ -1517,7 +1526,7 @@ babel-jest@^24.8.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
-babel-literal-to-ast@^2.0.0:
+babel-literal-to-ast@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/babel-literal-to-ast/-/babel-literal-to-ast-2.1.0.tgz#c8b12f9c36a8cee13572d65aabf6cff8adb1e8b3"
   integrity sha512-CxfpQ0ysQ0bZOhlaPgcWjl79Em16Rhqc6++UAFn0A3duiXmuyhhj8yyl9PYbj0I0CyjrHovdDbp2QEKT7uIMxw==
@@ -1542,7 +1551,7 @@ babel-plugin-jest-hoist@^24.6.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@^2.4.2, babel-plugin-macros@^2.5.1:
+babel-plugin-macros@^2.5.0, babel-plugin-macros@^2.5.1:
   version "2.5.1"
   resolved "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz#4a119ac2c2e19b458c259b9accd7ee34fd57ec6f"
   integrity sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==
@@ -3170,27 +3179,20 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-graphql-tag.macro@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/graphql-tag.macro/-/graphql-tag.macro-2.1.0.tgz#442e10f766c92411a4627ff9dbb136019b40242f"
-  integrity sha512-hH+8bnhgFz2sWPsKAGDhCJ6QHGQxxI2AyzgZUQ9eWNF3aIeSUbSheP+0Fh0FSTVu6NDBVpM0Iq7TBItTQQsVWA==
-  dependencies:
-    babel-literal-to-ast "^2.0.0"
-    babel-plugin-macros "^2.4.2"
-    graphql "^14.0.2"
-    graphql-tag "^2.10.0"
-
-graphql-tag@^2.10.0, graphql-tag@^2.10.1:
+graphql-tag@^2.10.1:
   version "2.10.1"
   resolved "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
 
-graphql@^14.0.2:
-  version "14.3.1"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-14.3.1.tgz#b3aa50e61a841ada3c1f9ccda101c483f8e8c807"
-  integrity sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==
+graphql.macro@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.npmjs.org/graphql.macro/-/graphql.macro-1.4.2.tgz#183c347828cb0319a6fe02690b2023b30b34cbc5"
+  integrity sha512-vcIaStPgS65gp5i1M3DSBimNVkyus0Z7k4VObWAyZS319tKlpX/TEIJSWTgOZU5k8dn4RRzGoS/elQhX2E6yBw==
   dependencies:
-    iterall "^1.2.2"
+    "@babel/template" "^7.4.4"
+    babel-literal-to-ast "^2.1.0"
+    babel-plugin-macros "^2.5.0"
+    graphql-tag "^2.10.1"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -3777,11 +3779,6 @@ istanbul-reports@^2.1.1:
   integrity sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==
   dependencies:
     handlebars "^4.1.0"
-
-iterall@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
-  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 jest-changed-files@^24.8.0:
   version "24.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,17 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/generator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz#174a215eb843fc392c7edcaabeaa873de6e8f041"
+  integrity sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==
+  dependencies:
+    "@babel/types" "^7.4.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.11"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
@@ -82,6 +93,13 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
+"@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
+  dependencies:
+    "@babel/types" "^7.4.4"
+
 "@babel/helpers@^7.2.0":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.3.1.tgz#949eec9ea4b45d3210feb7dc1c22db664c9e44b9"
@@ -109,6 +127,11 @@
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
   integrity sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==
+
+"@babel/parser@^7.1.6", "@babel/parser@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
+  integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0":
   version "7.2.0"
@@ -148,6 +171,21 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
+"@babel/traverse@^7.1.6":
+  version "7.4.5"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216"
+  integrity sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.4.5"
+    "@babel/types" "^7.4.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
 "@babel/types@^7.0.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.2.tgz#424f5be4be633fff33fb83ab8d67e4a8290f5a2f"
@@ -155,6 +193,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.1.6", "@babel/types@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
+  integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":
@@ -1470,6 +1517,15 @@ babel-jest@^24.8.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
+babel-literal-to-ast@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/babel-literal-to-ast/-/babel-literal-to-ast-2.1.0.tgz#c8b12f9c36a8cee13572d65aabf6cff8adb1e8b3"
+  integrity sha512-CxfpQ0ysQ0bZOhlaPgcWjl79Em16Rhqc6++UAFn0A3duiXmuyhhj8yyl9PYbj0I0CyjrHovdDbp2QEKT7uIMxw==
+  dependencies:
+    "@babel/parser" "^7.1.6"
+    "@babel/traverse" "^7.1.6"
+    "@babel/types" "^7.1.6"
+
 babel-plugin-istanbul@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.0.tgz#6892f529eff65a3e2d33d87dc5888ffa2ecd4a30"
@@ -1486,7 +1542,7 @@ babel-plugin-jest-hoist@^24.6.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@^2.5.1:
+babel-plugin-macros@^2.4.2, babel-plugin-macros@^2.5.1:
   version "2.5.1"
   resolved "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz#4a119ac2c2e19b458c259b9accd7ee34fd57ec6f"
   integrity sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==
@@ -3114,6 +3170,28 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
+graphql-tag.macro@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/graphql-tag.macro/-/graphql-tag.macro-2.1.0.tgz#442e10f766c92411a4627ff9dbb136019b40242f"
+  integrity sha512-hH+8bnhgFz2sWPsKAGDhCJ6QHGQxxI2AyzgZUQ9eWNF3aIeSUbSheP+0Fh0FSTVu6NDBVpM0Iq7TBItTQQsVWA==
+  dependencies:
+    babel-literal-to-ast "^2.0.0"
+    babel-plugin-macros "^2.4.2"
+    graphql "^14.0.2"
+    graphql-tag "^2.10.0"
+
+graphql-tag@^2.10.0, graphql-tag@^2.10.1:
+  version "2.10.1"
+  resolved "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
+  integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
+
+graphql@^14.0.2:
+  version "14.3.1"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-14.3.1.tgz#b3aa50e61a841ada3c1f9ccda101c483f8e8c807"
+  integrity sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==
+  dependencies:
+    iterall "^1.2.2"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -3699,6 +3777,11 @@ istanbul-reports@^2.1.1:
   integrity sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==
   dependencies:
     handlebars "^4.1.0"
+
+iterall@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 jest-changed-files@^24.8.0:
   version "24.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,13 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
+  integrity sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-function-name@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
@@ -53,6 +60,13 @@
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
   integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-module-imports@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
+  integrity sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==
   dependencies:
     "@babel/types" "^7.0.0"
 
@@ -103,6 +117,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/runtime@^7.4.2":
+  version "7.4.5"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
@@ -143,6 +164,23 @@
   dependencies:
     exec-sh "^0.3.2"
     minimist "^1.2.0"
+
+"@emotion/is-prop-valid@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
+  integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
+  dependencies:
+    "@emotion/memoize" "0.7.1"
+
+"@emotion/memoize@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
+  integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
+
+"@emotion/unitless@^0.7.0":
+  version "0.7.3"
+  resolved "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
+  integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
 
 "@jest/console@^24.7.1":
   version "24.7.1"
@@ -1448,6 +1486,30 @@ babel-plugin-jest-hoist@^24.6.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-macros@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz#4a119ac2c2e19b458c259b9accd7ee34fd57ec6f"
+  integrity sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==
+  dependencies:
+    "@babel/runtime" "^7.4.2"
+    cosmiconfig "^5.2.0"
+    resolve "^1.10.0"
+
+"babel-plugin-styled-components@>= 1":
+  version "1.10.0"
+  resolved "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
+  integrity sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.10"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
 babel-preset-jest@^24.6.0:
   version "24.6.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz#66f06136eefce87797539c0d63f1769cc3915984"
@@ -1658,6 +1720,11 @@ camelcase@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
   integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -1972,6 +2039,16 @@ cosmiconfig@^5.0.7, cosmiconfig@^5.1.0:
     lodash.get "^4.4.2"
     parse-json "^4.0.0"
 
+cosmiconfig@^5.2.0:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
+  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.1"
+    parse-json "^4.0.0"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1982,6 +2059,20 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
+css-to-react-native@^2.2.2:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.1.tgz#cf0f61e0514846e2d4dc188b0886e29d8bef64a2"
+  integrity sha512-yO+oEx1Lf+hDKasqQRVrAvzMCz825Huh1VMlEEDlRWyAhFb/FWb6I0KpEF1PkyKQ7NEdcx9d5M2ZEWgJAsgPvQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^3.3.0"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.6"
@@ -2453,7 +2544,7 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@^5.15.3:
+eslint@^5.15.3, eslint@^5.16.0:
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
   integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
@@ -3974,6 +4065,14 @@ js-yaml@^3.13.0, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -4383,6 +4482,11 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
+
+memoize-one@^5.0.0:
+  version "5.0.4"
+  resolved "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz#005928aced5c43d890a4dfab18ca908b0ec92cbc"
+  integrity sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==
 
 meow@^3.3.0:
   version "3.7.0"
@@ -5263,6 +5367,11 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postcss-value-parser@^3.3.0:
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
+  integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -5328,7 +5437,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.7.2:
+prop-types@^15.5.4, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -5423,6 +5532,11 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-is@^16.6.0:
+  version "16.8.6"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-is@^16.8.1:
   version "16.8.1"
@@ -5575,6 +5689,11 @@ redent@^2.0.0:
   dependencies:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -6187,7 +6306,34 @@ strong-log-transformer@^2.0.0:
     minimist "^1.2.0"
     through "^2.3.4"
 
-supports-color@^5.3.0:
+styled-components@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/styled-components/-/styled-components-4.2.0.tgz#811fbbec4d64c7189f6c7482b9eb6fefa7fefef7"
+  integrity sha512-L/LzkL3ZbBhqIVHdR7DbYujy4tqvTNRfc+4JWDCYyhTatI+8CRRQUmdaR0+ARl03DWsfKLhjewll5uNLrqrl4A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.7.3"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^5.0.0"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
+
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
## WHY & WHAT

I create `eslint-plugin-use-macros`. This plugin provides the rules to use the babel macros for specific libraries (such as `styled-components` and `graphql-tag`.)

- `styled-components` -> `styled-components/macro`
  - `use-macros/styled-components`
- `graphql-tag` -> `graphql.macro`
  - `use-macros/graphql-tag`

For example, the project doesn't install the `babel-plugin-macros`, this plugin shows the error message to install the `babel-plugin-macros`.
If `graphql.macro` is not installled, this plugin shows the error message to install `graphql.macro`.
And then the project has two libraries in the dependency graph, this plugin shows the error message that you should import the `gql` from `graphql.macro`.