### PR TITLE
Fix babel-plugin-macros check

### DIFF
--- a/packages/eslint-plugin-use-macros/createUseMacro.js
+++ b/packages/eslint-plugin-use-macros/createUseMacro.js
@@ -17,17 +17,17 @@ module.exports = function createUseMacro(from, to, context) {
   }
 
   return function(node) {
-    if (!BABEL_PLUGIN_MACROS_INSTALLED) {
-      context.report({
-        node,
-        message: "Please install 'babel-plugin-macro' to use macro",
-      });
-      return;
-    }
-
     const importName = node.source.value.trim();
 
     if (importName === from) {
+      if (!BABEL_PLUGIN_MACROS_INSTALLED) {
+        context.report({
+          node,
+          message: "Please install 'babel-plugin-macro' to use macro",
+        });
+        return;
+      }
+
       if (!TARGET_LIBRARY_INSTALLED) {
         context.report({
           node,

--- a/packages/eslint-plugin-use-macros/rules/GraphQLTag.js
+++ b/packages/eslint-plugin-use-macros/rules/GraphQLTag.js
@@ -26,17 +26,17 @@ module.exports = {
   create(context) {
     return {
       ImportDeclaration(node) {
-        if (!BABEL_PLUGIN_MACROS_INSTALLED) {
-          context.report({
-            node,
-            message: 'Please install "babel-plugin-macro" to use macro',
-          });
-          return;
-        }
-
         const importName = node.source.value.trim();
 
         if (importName === FROM) {
+          if (!BABEL_PLUGIN_MACROS_INSTALLED) {
+            context.report({
+              node,
+              message: 'Please install "babel-plugin-macro" to use macro',
+            });
+            return;
+          }
+
           if (!GRAPHQL_MACRO_INSTALLED) {
             context.report({
               node,


### PR DESCRIPTION
## WHY & WHAT

We should check the installation of `babel-plugin-macros` if the `importName` is same as `styled-components` / `graphql-tag`.