### PR TITLE
Fix ls-files optional argument format

### DIFF
--- a/packages/frolint/git.js
+++ b/packages/frolint/git.js
@@ -13,7 +13,7 @@ function getUnstagedFiles(cwd) {
 }
 
 function getAllFiles(cwd, extensions) {
-  const { stdout } = execa.commandSync(`git ls-files ${extensions.map(ext => `*${ext}`).join(" ")}`, {
+  const { stdout } = execa.commandSync(`git ls-files ${extensions.map(ext => `"**/*${ext}"`).join(" ")}`, {
     cwd,
     shell: true,
   });


### PR DESCRIPTION
## WHY & WHAT

Fix `git ls-files` argument format. If you specify the `*.ts` argument for ls-files command, this displays only current working directory files which are matched with the `.ts` extension name.
We should use the format such as `"**/*.ts"`. This format can display the files recursively.