### PR TITLE
Change node versions in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,21 +31,21 @@ commands:
           command: yarn test
 
 jobs:
-  node-v8:
-    docker:
-      - image: node:8
-    working_directory: ~/repo
-    steps:
-      - test-nodejs
   node-v10:
     docker:
       - image: node:10
     working_directory: ~/repo
     steps:
       - test-nodejs
-  node-v11:
+  node-v12:
     docker:
-      - image: node:11
+      - image: node:12
+    working_directory: ~/repo
+    steps:
+      - test-nodejs
+  node-v13:
+    docker:
+      - image: node:13
     working_directory: ~/repo
     steps:
       - test-nodejs
@@ -53,6 +53,6 @@ jobs:
 workflows:
   node-multi-build:
     jobs:
-      - node-v8
       - node-v10
-      - node-v11
+      - node-v12
+      - node-v13


### PR DESCRIPTION
## WHY & WHAT

Released Node.js v13 and then v11 is End-of-Life.