### PR TITLE
Move TypeScript to peerDependencies in wantedly-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lerna-changelog": "^1.0.0",
     "mock-fs": "^4.8.0",
     "ts-jest": "^24.1.0",
-    "typescript": "^3.7.2"
+    "typescript": "^3.7.3"
   },
   "workspaces": [
     "packages/*"

--- a/packages/eslint-config-wantedly-typescript/package.json
+++ b/packages/eslint-config-wantedly-typescript/package.json
@@ -14,8 +14,10 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-react-hooks": "^2.0.1",
-    "eslint-plugin-use-macros": "^0.8.4",
-    "typescript": "^3.3.4000"
+    "eslint-plugin-use-macros": "^0.8.4"
+  },
+  "peerDependencies": {
+    "typescript": "^3.7.3"
   },
   "homepage": "https://github.com/wantedly/frolint",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7526,7 +7526,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.3.4000, typescript@^3.7.2:
+typescript@^3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==


### PR DESCRIPTION
## WHY & WHAT

If the `typescript` is located in `dependencies`, the package manager downloads the different versions of TypeScript in the project.
Move to `peerDependencies` in `eslint-config-wantedly-typescript`