### PR TITLE
Add `nexus-upper-case-enum-members` rule

### DIFF
--- a/packages/eslint-plugin-wantedly/README.md
+++ b/packages/eslint-plugin-wantedly/README.md
@@ -20,3 +20,5 @@ This plugin provides the opinionated rules in Wantedly.
   - Check the field name which is camelCase if the code using `nexus`
 - [`wantedly/nexus-pascal-case-type-name`](./docs/rules/nexus-pascal-case-type-name.md)
   - Check the type name which is PascalCase if the code using `nexus`
+- [`wantedly/nexus-upper-case-enum-members`](./docs/rules/nexus-upper-case-enum-members.md)
+  - Check the enum members are UPPER_CASE if the code using `nexus`

--- a/packages/eslint-plugin-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-plugin-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -43,6 +43,13 @@ Object {
         "type": "suggestion",
       },
     },
+    "nexus-upper-case-enum-members": Object {
+      "create": [Function],
+      "meta": Object {
+        "fixable": "code",
+        "type": "suggestion",
+      },
+    },
   },
 }
 `;

--- a/packages/eslint-plugin-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-plugin-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -46,6 +46,9 @@ Object {
     "nexus-upper-case-enum-members": Object {
       "create": [Function],
       "meta": Object {
+        "docs": Object {
+          "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/nexus-upper-case-enum-members.md",
+        },
         "fixable": "code",
         "type": "suggestion",
       },

--- a/packages/eslint-plugin-wantedly/docs/rules/nexus-upper-case-enum-members.md
+++ b/packages/eslint-plugin-wantedly/docs/rules/nexus-upper-case-enum-members.md
@@ -1,0 +1,59 @@
+# Check the enum members are UPPER_CASE if the code using `nexus` (`wantedly/nexus-upper-case-enum-members`)
+
+## Rule Details
+
+#### Valid
+
+```js
+import { enumType } from "nexus";
+
+// Array literal
+const Episode = enumType({
+  name: "Episode",
+  members: ["NEW_HOPE", "EMPIRE", "JEDI"],
+});
+
+// Object literal
+const Episode = enumType({
+  name: "Episode",
+  members: { NEW_HOPE: 1, EMPIRE: 2, JEDI: 3 },
+});
+```
+
+#### Invalid
+
+```js
+import { enumType } from "nexus";
+
+// Array literal
+const Episode = enumType({
+  name: "Episode",
+  members: ["newHope", "empire", "jedi"],
+});
+
+// Object literal
+const Episode = enumType({
+  name: "Episode",
+  members: { newHope: 1, empire: 2, jedi: 3 },
+});
+```
+
+This rule is automatically fix some problems reported by this rule if the `autofix` option is true.
+
+## Options
+
+#### `autofix`
+
+The `autofix` option is enabling the auto fix function.
+
+```json
+{
+  "rule": {
+    "wantedly/nexus-upper-case-enum-members": ["error", { "autofix": true }]
+  }
+}
+```
+
+```js
+/* eslint wantedly/nexus-upper-case-enum-members: ["error", { "autofix": true }] */
+```

--- a/packages/eslint-plugin-wantedly/index.js
+++ b/packages/eslint-plugin-wantedly/index.js
@@ -2,6 +2,7 @@ const GraphQLOperationName = require("./rules/GraphQLOperationName");
 const GraphQLPascalCaseTypeName = require("./rules/GraphQLPascalCaseTypeName");
 const NexusCamelCaseFieldName = require("./rules/NexusCamelCaseFieldName");
 const NexusPascalCaseTypeName = require("./rules/NexusPascalCaseTypeName");
+const NexusUpperCaseEnumMembers = require("./rules/NexusUpperCaseEnumMembers");
 
 module.exports = {
   rules: {
@@ -9,5 +10,6 @@ module.exports = {
     [GraphQLPascalCaseTypeName.RULE_NAME]: GraphQLPascalCaseTypeName.RULE,
     [NexusCamelCaseFieldName.RULE_NAME]: NexusCamelCaseFieldName.RULE,
     [NexusPascalCaseTypeName.RULE_NAME]: NexusPascalCaseTypeName.RULE,
+    [NexusUpperCaseEnumMembers.RULE_NAME]: NexusUpperCaseEnumMembers.RULE,
   },
 };

--- a/packages/eslint-plugin-wantedly/package.json
+++ b/packages/eslint-plugin-wantedly/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "camel-case": "^4.1.1",
-    "pascal-case": "^3.1.1"
+    "pascal-case": "^3.1.1",
+    "snake-case": "^3.0.3"
   },
   "devDependencies": {
     "eslint": "^6.0.1",

--- a/packages/eslint-plugin-wantedly/rules/NexusUpperCaseEnumMembers.js
+++ b/packages/eslint-plugin-wantedly/rules/NexusUpperCaseEnumMembers.js
@@ -1,0 +1,179 @@
+const { Linter } = require("eslint");
+const { getOptionWithDefault } = require("./utils");
+
+const linter = new Linter();
+const RULE_NAME = "nexus-upper-case-enum-members";
+
+// Represents the default option and schema for graphql-operation-name option
+const DEFAULT_OPTION = {
+  autofix: false,
+};
+
+linter.defineRule(RULE_NAME, {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+  },
+  create(context) {
+    let isNexusUsed = false;
+    const option = getOptionWithDefault(context, DEFAULT_OPTION);
+    const autofixEnabled = option.autofix;
+
+    return {
+      ImportDeclaration(importDeclaration) {
+        if (
+          importDeclaration.source &&
+          importDeclaration.source.type === "Literal" &&
+          importDeclaration.source.value === "nexus"
+        ) {
+          isNexusUsed = true;
+        }
+      },
+
+      Property(node) {
+        if (!isNexusUsed) {
+          return;
+        }
+
+        if (node.key.name !== "members") {
+          return;
+        }
+
+        if (node.value.type === "ArrayExpression") {
+          const elements = node.value.elements;
+          elements.forEach(elem => {
+            if (elem.type !== "Literal") {
+              return;
+            }
+
+            const value = elem.value || "";
+            const upperCased = value.toUpperCase();
+
+            if (value !== upperCased) {
+              context.report({
+                node: elem,
+                message: "The enum member `{{value}}` should be UPPER_CASE",
+                data: {
+                  value,
+                },
+                fix(fixer) {
+                  if (autofixEnabled) {
+                    const [start, end] = elem.range;
+                    return fixer.replaceTextRange([start + 1, end - 1], upperCased);
+                  }
+                },
+              });
+            }
+          });
+        }
+
+        if (node.value.type === "ObjectExpression") {
+          const properties = node.value.properties;
+          properties.forEach(property => {
+            const keyName = property.key.name || "";
+            const upperCased = keyName.toUpperCase();
+
+            if (keyName !== upperCased) {
+              context.report({
+                node: property.key,
+                message: "The enum member `{{keyName}}` should be UPPER_CASE",
+                data: {
+                  keyName,
+                },
+                fix(fixer) {
+                  if (autofixEnabled) {
+                    const [start, end] = property.key.range;
+                    return fixer.replaceTextRange([start, end], upperCased);
+                  }
+                },
+              });
+            }
+          });
+        }
+
+        if (node.value.type === "Identifier") {
+          const membersVariableName = node.value.name;
+          const sourceCode = context.getSourceCode();
+          const tokensAndComments = sourceCode.tokensAndComments;
+          if (!Array.isArray(tokensAndComments)) {
+            return;
+          }
+
+          const maybeToken = tokensAndComments.find(
+            token => token.type === "Identifier" && token.value === membersVariableName
+          );
+          if (!maybeToken) {
+            return;
+          }
+
+          const maybeNode = sourceCode.getNodeByRangeIndex(maybeToken.start);
+          if (!maybeNode) {
+            return;
+          }
+
+          const parent = maybeNode.parent;
+          if (!parent || parent.type !== "VariableDeclarator" || !parent.init) {
+            return;
+          }
+
+          if (parent.init.type === "ArrayExpression") {
+            /**
+             * In this case, the variable is array
+             * e.g. const members = ["foo", "bar"]
+             */
+            const elements = parent.init.elements;
+            elements.forEach(elem => {
+              if (elem.type !== "Literal") {
+                return;
+              }
+
+              const value = elem.value || "";
+              const upperCased = value.toUpperCase();
+
+              if (value !== upperCased) {
+                context.report({
+                  node: elem,
+                  message: "The enum member `{{value}}` should be UPPER_CASE",
+                  data: {
+                    value,
+                  },
+                  // In this situation, we should not fix the issue automatically.
+                  // We cannot know the variable is used or not in other file.
+                  // fix(fixer) {},
+                });
+              }
+            });
+          } else if (parent.init.type === "ObjectExpression") {
+            /**
+             * In this case, the variable is object
+             * e.g. const members = { foo: 1, bar: 2 }
+             */
+            const properties = parent.init.properties;
+            properties.forEach(property => {
+              const keyName = property.key.name || "";
+              const upperCased = keyName.toUpperCase();
+
+              if (keyName !== upperCased) {
+                context.report({
+                  node: property,
+                  message: "The enum member `{{keyName}}` should be UPPER_CASE",
+                  data: {
+                    keyName,
+                  },
+                  // In this situation, we should not fix the issue automatically.
+                  // We cannot know the variable is used or not in other file.
+                  // fix(fixer) {},
+                });
+              }
+            });
+          }
+        }
+      },
+    };
+  },
+});
+
+module.exports = {
+  RULE_NAME,
+  RULE: linter.getRules().get(RULE_NAME),
+};

--- a/packages/eslint-plugin-wantedly/rules/NexusUpperCaseEnumMembers.js
+++ b/packages/eslint-plugin-wantedly/rules/NexusUpperCaseEnumMembers.js
@@ -1,3 +1,4 @@
+const { snakeCase } = require("snake-case");
 const { Linter } = require("eslint");
 const { getOptionWithDefault } = require("./utils");
 
@@ -47,7 +48,7 @@ linter.defineRule(RULE_NAME, {
             }
 
             const value = elem.value || "";
-            const upperCased = value.toUpperCase();
+            const upperCased = snakeCase(value).toUpperCase();
 
             if (value !== upperCased) {
               context.report({
@@ -71,7 +72,7 @@ linter.defineRule(RULE_NAME, {
           const properties = node.value.properties;
           properties.forEach(property => {
             const keyName = property.key.name || "";
-            const upperCased = keyName.toUpperCase();
+            const upperCased = snakeCase(keyName).toUpperCase();
 
             if (keyName !== upperCased) {
               context.report({
@@ -128,7 +129,7 @@ linter.defineRule(RULE_NAME, {
               }
 
               const value = elem.value || "";
-              const upperCased = value.toUpperCase();
+              const upperCased = snakeCase(value).toUpperCase();
 
               if (value !== upperCased) {
                 context.report({
@@ -151,7 +152,7 @@ linter.defineRule(RULE_NAME, {
             const properties = parent.init.properties;
             properties.forEach(property => {
               const keyName = property.key.name || "";
-              const upperCased = keyName.toUpperCase();
+              const upperCased = snakeCase(keyName).toUpperCase();
 
               if (keyName !== upperCased) {
                 context.report({

--- a/packages/eslint-plugin-wantedly/rules/NexusUpperCaseEnumMembers.js
+++ b/packages/eslint-plugin-wantedly/rules/NexusUpperCaseEnumMembers.js
@@ -43,6 +43,15 @@ linter.defineRule(RULE_NAME, {
           return;
         }
 
+        let enumName;
+        if (node.parent) {
+          const nameProperty = node.parent.properties.find(property => property.key.name === "name");
+
+          if (nameProperty) {
+            enumName = nameProperty.value.value;
+          }
+        }
+
         if (node.value.type === "ArrayExpression") {
           const elements = node.value.elements;
           elements.forEach(elem => {
@@ -56,9 +65,13 @@ linter.defineRule(RULE_NAME, {
             if (value !== upperCased) {
               context.report({
                 node: elem,
-                message: "The enum member `{{value}}` should be UPPER_CASE",
+                message:
+                  typeof enumName === "string"
+                    ? "The enum member `{{enumName}}.{{value}}` should be UPPER_CASE"
+                    : "The enum member `{{value}}` should be UPPER_CASE",
                 data: {
                   value,
+                  enumName,
                 },
                 fix(fixer) {
                   if (autofixEnabled) {
@@ -69,6 +82,8 @@ linter.defineRule(RULE_NAME, {
               });
             }
           });
+
+          return;
         }
 
         if (node.value.type === "ObjectExpression") {
@@ -80,9 +95,13 @@ linter.defineRule(RULE_NAME, {
             if (keyName !== upperCased) {
               context.report({
                 node: property.key,
-                message: "The enum member `{{keyName}}` should be UPPER_CASE",
+                message:
+                  typeof enumName === "string"
+                    ? "The enum member `{{enumName}}.{{keyName}}` should be UPPER_CASE"
+                    : "The enum member `{{keyName}}` should be UPPER_CASE",
                 data: {
                   keyName,
+                  enumName,
                 },
                 fix(fixer) {
                   if (autofixEnabled) {
@@ -93,6 +112,8 @@ linter.defineRule(RULE_NAME, {
               });
             }
           });
+
+          return;
         }
 
         if (node.value.type === "Identifier") {
@@ -110,7 +131,8 @@ linter.defineRule(RULE_NAME, {
             return;
           }
 
-          const maybeNode = sourceCode.getNodeByRangeIndex(maybeToken.start);
+          const tokenStartIndex = maybeToken.start || maybeToken.range[0];
+          const maybeNode = sourceCode.getNodeByRangeIndex(tokenStartIndex);
           if (!maybeNode) {
             return;
           }
@@ -137,9 +159,13 @@ linter.defineRule(RULE_NAME, {
               if (value !== upperCased) {
                 context.report({
                   node: elem,
-                  message: "The enum member `{{value}}` should be UPPER_CASE",
+                  message:
+                    typeof enumName === "string"
+                      ? "The enum member `{{enumName}}.{{value}}` should be UPPER_CASE"
+                      : "The enum member `{{value}}` should be UPPER_CASE",
                   data: {
                     value,
+                    enumName,
                   },
                   // In this situation, we should not fix the issue automatically.
                   // We cannot know the variable is used or not in other file.
@@ -160,9 +186,13 @@ linter.defineRule(RULE_NAME, {
               if (keyName !== upperCased) {
                 context.report({
                   node: property,
-                  message: "The enum member `{{keyName}}` should be UPPER_CASE",
+                  message:
+                    typeof enumName === "string"
+                      ? "The enum member `{{enumName}}.{{keyName}}` should be UPPER_CASE"
+                      : "The enum member `{{keyName}}` should be UPPER_CASE",
                   data: {
                     keyName,
+                    enumName,
                   },
                   // In this situation, we should not fix the issue automatically.
                   // We cannot know the variable is used or not in other file.
@@ -171,6 +201,8 @@ linter.defineRule(RULE_NAME, {
               }
             });
           }
+
+          return;
         }
       },
     };

--- a/packages/eslint-plugin-wantedly/rules/NexusUpperCaseEnumMembers.js
+++ b/packages/eslint-plugin-wantedly/rules/NexusUpperCaseEnumMembers.js
@@ -1,6 +1,6 @@
 const { snakeCase } = require("snake-case");
 const { Linter } = require("eslint");
-const { getOptionWithDefault } = require("./utils");
+const { getOptionWithDefault, docsUrl } = require("./utils");
 
 const linter = new Linter();
 const RULE_NAME = "nexus-upper-case-enum-members";
@@ -14,6 +14,9 @@ linter.defineRule(RULE_NAME, {
   meta: {
     type: "suggestion",
     fixable: "code",
+    docs: {
+      url: docsUrl(RULE_NAME),
+    },
   },
   create(context) {
     let isNexusUsed = false;

--- a/packages/eslint-plugin-wantedly/rules/__tests__/NexusUpperCaseEnumMembers.test.js
+++ b/packages/eslint-plugin-wantedly/rules/__tests__/NexusUpperCaseEnumMembers.test.js
@@ -1,0 +1,104 @@
+const RuleTester = require("eslint").RuleTester;
+const ESLintConfigWantedly = require("eslint-config-wantedly/without-react");
+const rule = require("../NexusUpperCaseEnumMembers");
+
+RuleTester.setDefaultConfig({
+  parser: require.resolve(ESLintConfigWantedly.parser),
+  parserOptions: ESLintConfigWantedly.parserOptions,
+});
+
+const ruleTester = new RuleTester();
+ruleTester.run(rule.RULE_NAME, rule.RULE, {
+  valid: [],
+  invalid: [
+    {
+      code: `import { enumType } from "nexus";
+const Episode = enumType({
+  name: "Episode",
+  members: ["newhope", "empire", "jedi"],
+});`,
+      errors: [
+        "The enum member `newhope` should be UPPER_CASE",
+        "The enum member `empire` should be UPPER_CASE",
+        "The enum member `jedi` should be UPPER_CASE",
+      ],
+    },
+    {
+      code: `import { enumType } from "nexus";
+const Episode = enumType({
+  name: "Episode",
+  members: ["newhope", "empire", "jedi"],
+});`,
+      output: `import { enumType } from "nexus";
+const Episode = enumType({
+  name: "Episode",
+  members: ["NEWHOPE", "EMPIRE", "JEDI"],
+});`,
+      errors: [
+        "The enum member `newhope` should be UPPER_CASE",
+        "The enum member `empire` should be UPPER_CASE",
+        "The enum member `jedi` should be UPPER_CASE",
+      ],
+      options: [{ autofix: true }],
+    },
+
+    {
+      code: `import { enumType } from "nexus";
+const Episode = enumType({
+  name: "Episode",
+  members: { newhope: 1, empire: 2, jedi: 3 },
+});`,
+      errors: [
+        "The enum member `newhope` should be UPPER_CASE",
+        "The enum member `empire` should be UPPER_CASE",
+        "The enum member `jedi` should be UPPER_CASE",
+      ],
+    },
+    {
+      code: `import { enumType } from "nexus";
+const Episode = enumType({
+  name: "Episode",
+  members: { newhope: 1, empire: 2, jedi: 3 },
+});`,
+      output: `import { enumType } from "nexus";
+const Episode = enumType({
+  name: "Episode",
+  members: { NEWHOPE: 1, EMPIRE: 2, JEDI: 3 },
+});`,
+      errors: [
+        "The enum member `newhope` should be UPPER_CASE",
+        "The enum member `empire` should be UPPER_CASE",
+        "The enum member `jedi` should be UPPER_CASE",
+      ],
+      options: [{ autofix: true }],
+    },
+
+    {
+      code: `import { enumType } from "nexus";
+const members = ["newhope", "empire", "jedi"];
+const Episode = enumType({
+  name: "Episode",
+  members,
+});`,
+      errors: [
+        "The enum member `newhope` should be UPPER_CASE",
+        "The enum member `empire` should be UPPER_CASE",
+        "The enum member `jedi` should be UPPER_CASE",
+      ],
+    },
+
+    {
+      code: `import { enumType } from "nexus";
+const members = { newhope: 1, empire: 2, jedi: 3 };
+const Episode = enumType({
+  name: "Episode",
+  members,
+});`,
+      errors: [
+        "The enum member `newhope` should be UPPER_CASE",
+        "The enum member `empire` should be UPPER_CASE",
+        "The enum member `jedi` should be UPPER_CASE",
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-wantedly/rules/__tests__/NexusUpperCaseEnumMembers.test.js
+++ b/packages/eslint-plugin-wantedly/rules/__tests__/NexusUpperCaseEnumMembers.test.js
@@ -18,9 +18,9 @@ const Episode = enumType({
   members: ["newhope", "empire", "jedi"],
 });`,
       errors: [
-        "The enum member `newhope` should be UPPER_CASE",
-        "The enum member `empire` should be UPPER_CASE",
-        "The enum member `jedi` should be UPPER_CASE",
+        "The enum member `Episode.newhope` should be UPPER_CASE",
+        "The enum member `Episode.empire` should be UPPER_CASE",
+        "The enum member `Episode.jedi` should be UPPER_CASE",
       ],
     },
     {
@@ -35,9 +35,9 @@ const Episode = enumType({
   members: ["NEW_HOPE", "EMPIRE", "JEDI"],
 });`,
       errors: [
-        "The enum member `newHope` should be UPPER_CASE",
-        "The enum member `empire` should be UPPER_CASE",
-        "The enum member `jedi` should be UPPER_CASE",
+        "The enum member `Episode.newHope` should be UPPER_CASE",
+        "The enum member `Episode.empire` should be UPPER_CASE",
+        "The enum member `Episode.jedi` should be UPPER_CASE",
       ],
       options: [{ autofix: true }],
     },
@@ -49,9 +49,9 @@ const Episode = enumType({
   members: { newhope: 1, empire: 2, jedi: 3 },
 });`,
       errors: [
-        "The enum member `newhope` should be UPPER_CASE",
-        "The enum member `empire` should be UPPER_CASE",
-        "The enum member `jedi` should be UPPER_CASE",
+        "The enum member `Episode.newhope` should be UPPER_CASE",
+        "The enum member `Episode.empire` should be UPPER_CASE",
+        "The enum member `Episode.jedi` should be UPPER_CASE",
       ],
     },
     {
@@ -66,9 +66,9 @@ const Episode = enumType({
   members: { NEWHOPE: 1, EMPIRE: 2, JEDI: 3 },
 });`,
       errors: [
-        "The enum member `newhope` should be UPPER_CASE",
-        "The enum member `empire` should be UPPER_CASE",
-        "The enum member `jedi` should be UPPER_CASE",
+        "The enum member `Episode.newhope` should be UPPER_CASE",
+        "The enum member `Episode.empire` should be UPPER_CASE",
+        "The enum member `Episode.jedi` should be UPPER_CASE",
       ],
       options: [{ autofix: true }],
     },
@@ -81,9 +81,9 @@ const Episode = enumType({
   members,
 });`,
       errors: [
-        "The enum member `newhope` should be UPPER_CASE",
-        "The enum member `empire` should be UPPER_CASE",
-        "The enum member `jedi` should be UPPER_CASE",
+        "The enum member `Episode.newhope` should be UPPER_CASE",
+        "The enum member `Episode.empire` should be UPPER_CASE",
+        "The enum member `Episode.jedi` should be UPPER_CASE",
       ],
     },
 
@@ -95,9 +95,9 @@ const Episode = enumType({
   members,
 });`,
       errors: [
-        "The enum member `newhope` should be UPPER_CASE",
-        "The enum member `empire` should be UPPER_CASE",
-        "The enum member `jedi` should be UPPER_CASE",
+        "The enum member `Episode.newhope` should be UPPER_CASE",
+        "The enum member `Episode.empire` should be UPPER_CASE",
+        "The enum member `Episode.jedi` should be UPPER_CASE",
       ],
     },
   ],

--- a/packages/eslint-plugin-wantedly/rules/__tests__/NexusUpperCaseEnumMembers.test.js
+++ b/packages/eslint-plugin-wantedly/rules/__tests__/NexusUpperCaseEnumMembers.test.js
@@ -27,15 +27,15 @@ const Episode = enumType({
       code: `import { enumType } from "nexus";
 const Episode = enumType({
   name: "Episode",
-  members: ["newhope", "empire", "jedi"],
+  members: ["newHope", "empire", "jedi"],
 });`,
       output: `import { enumType } from "nexus";
 const Episode = enumType({
   name: "Episode",
-  members: ["NEWHOPE", "EMPIRE", "JEDI"],
+  members: ["NEW_HOPE", "EMPIRE", "JEDI"],
 });`,
       errors: [
-        "The enum member `newhope` should be UPPER_CASE",
+        "The enum member `newHope` should be UPPER_CASE",
         "The enum member `empire` should be UPPER_CASE",
         "The enum member `jedi` should be UPPER_CASE",
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,6 +2965,14 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+dot-case@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.3.tgz#21d3b52efaaba2ea5fda875bb1aa8124521cf4aa"
+  integrity sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==
+  dependencies:
+    no-case "^3.0.3"
+    tslib "^1.10.0"
+
 dot-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
@@ -7190,6 +7198,14 @@ smart-buffer@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.0.1.tgz#07ea1ca8d4db24eb4cac86537d7d18995221ace3"
   integrity sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg==
+
+snake-case@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.3.tgz#c598b822ab443fcbb145ae8a82c5e43526d5bbee"
+  integrity sha512-WM1sIXEO+rsAHBKjGf/6R1HBBcgbncKS08d2Aqec/mrDSpU80SiOU41hO7ny6DToHSyrlwTYzQBIK1FPSx4Y3Q==
+  dependencies:
+    dot-case "^3.0.3"
+    tslib "^1.10.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
## WHY & WHAT

Check the enum members are UPPER_CASE if the code using `nexus` (`wantedly/nexus-upper-case-enum-members`)

### Rule Details

#### Valid

```js
import { enumType } from "nexus";
// Array literal
const Episode = enumType({
  name: "Episode",
  members: ["NEW_HOPE", "EMPIRE", "JEDI"],
});
// Object literal
const Episode = enumType({
  name: "Episode",
  members: { NEW_HOPE: 1, EMPIRE: 2, JEDI: 3 },
});
```

#### Invalid

```js
import { enumType } from "nexus";
// Array literal
const Episode = enumType({
  name: "Episode",
  members: ["newHope", "empire", "jedi"],
});
// Object literal
const Episode = enumType({
  name: "Episode",
  members: { newHope: 1, empire: 2, jedi: 3 },
});
```

This rule is automatically fix some problems reported by this rule if the `autofix` option is true.

### Options

#### `autofix`

The `autofix` option is enabling the auto fix function.

```json
{
  "rule": {
    "wantedly/nexus-upper-case-enum-members": ["error", { "autofix": true }]
  }
}
```

```js
/* eslint wantedly/nexus-upper-case-enum-members: ["error", { "autofix": true }] */
```
