### PR TITLE
Create `nexus-type-description` rule

### DIFF
--- a/packages/eslint-plugin-wantedly/README.md
+++ b/packages/eslint-plugin-wantedly/README.md
@@ -22,3 +22,5 @@ This plugin provides the opinionated rules in Wantedly.
   - Check the type name which is PascalCase if the code using `nexus`
 - [`wantedly/nexus-upper-case-enum-members`](./docs/rules/nexus-upper-case-enum-members.md)
   - Check the enum members are UPPER_CASE if the code using `nexus`
+- [`wantedly/nexus-type-description`](./docs/rules/nexus-type-description.md)
+  - Validate that the types have descriptions if the code using `nexus`

--- a/packages/eslint-plugin-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-plugin-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -43,6 +43,15 @@ Object {
         "type": "suggestion",
       },
     },
+    "nexus-type-description": Object {
+      "create": [Function],
+      "meta": Object {
+        "docs": Object {
+          "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/nexus-type-description.md",
+        },
+        "type": "suggestion",
+      },
+    },
     "nexus-upper-case-enum-members": Object {
       "create": [Function],
       "meta": Object {

--- a/packages/eslint-plugin-wantedly/docs/rules/nexus-type-description.md
+++ b/packages/eslint-plugin-wantedly/docs/rules/nexus-type-description.md
@@ -1,0 +1,31 @@
+# Validate that the types have descriptions if the code using `nexus` (`wantedly/nexus-type-description`)
+
+## Rule Details
+
+#### Valid
+
+```js
+import { objectType } from "nexus";
+
+const Foo = objectType({
+  name: "Foo",
+  definitions(t) {
+    // define fields
+  },
+  description: "Foo represents the record of Foo",
+});
+```
+
+#### Invalid
+
+```js
+import { objectType } from "nexus";
+
+const Foo = objectType({
+  name: "Foo",
+  definitions(t) {
+    // define fields
+  },
+  // missing description field or the description is empty string
+});
+```

--- a/packages/eslint-plugin-wantedly/index.js
+++ b/packages/eslint-plugin-wantedly/index.js
@@ -3,6 +3,7 @@ const GraphQLPascalCaseTypeName = require("./rules/GraphQLPascalCaseTypeName");
 const NexusCamelCaseFieldName = require("./rules/NexusCamelCaseFieldName");
 const NexusPascalCaseTypeName = require("./rules/NexusPascalCaseTypeName");
 const NexusUpperCaseEnumMembers = require("./rules/NexusUpperCaseEnumMembers");
+const nexusTypeDescription = require("./rules/nexus-type-description");
 
 module.exports = {
   rules: {
@@ -11,5 +12,6 @@ module.exports = {
     [NexusCamelCaseFieldName.RULE_NAME]: NexusCamelCaseFieldName.RULE,
     [NexusPascalCaseTypeName.RULE_NAME]: NexusPascalCaseTypeName.RULE,
     [NexusUpperCaseEnumMembers.RULE_NAME]: NexusUpperCaseEnumMembers.RULE,
+    [nexusTypeDescription.RULE_NAME]: nexusTypeDescription.RULE,
   },
 };

--- a/packages/eslint-plugin-wantedly/rules/__tests__/nexus-type-description.test.js
+++ b/packages/eslint-plugin-wantedly/rules/__tests__/nexus-type-description.test.js
@@ -1,0 +1,100 @@
+const RuleTester = require("eslint").RuleTester;
+const ESLintConfigWantedly = require("eslint-config-wantedly/without-react");
+const rule = require("../nexus-type-description");
+
+RuleTester.setDefaultConfig({
+  parser: require.resolve(ESLintConfigWantedly.parser),
+  parserOptions: ESLintConfigWantedly.parserOptions,
+});
+
+const ruleTester = new RuleTester();
+ruleTester.run(rule.RULE_NAME, rule.RULE, {
+  valid: [
+    {
+      code: `import { objectType } from "nexus";
+const Foo = objectType({
+  name: "Foo",
+  definition(t) {
+    t.string("foo", { nullable: true });
+  },
+  description: "Foo represents the foo"
+});`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { objectType } from "nexus";
+const Foo = objectType({
+  name: "Foo",
+  definition(t) {
+    t.string("foo", { nullable: true });
+  },
+  description: ""
+});`,
+      errors: ["The objectType Foo is missing a description"],
+    },
+    {
+      code: `import { objectType } from "nexus";
+const Foo = objectType({
+  name: "Foo",
+  definition(t) {
+    t.string("foo", { nullable: true });
+  },
+});`,
+      errors: ["The objectType Foo is missing a description"],
+    },
+    {
+      code: `import { objectType } from "nexus";
+const Foo = objectType({
+  name: "Foo",
+  definition(t) { t.string("foo", { nullable: true }); },
+});`,
+      errors: ["The objectType Foo is missing a description"],
+    },
+
+    {
+      code: `import { unionType } from "nexus";
+const Foo = unionType({
+  name: "Foo",
+  definition(t) { t.members("Bar", "Baz"); },
+});`,
+      errors: ["The unionType Foo is missing a description"],
+    },
+
+    {
+      code: `import { scalarType } from "nexus";
+const Foo = scalarType({
+  name: "Foo",
+  serialize(v) { return v; },
+});`,
+      errors: ["The scalarType Foo is missing a description"],
+    },
+
+    {
+      code: `import { interfaceType } from "nexus";
+const Foo = interfaceType({
+  name: "Foo",
+  definition(t) { t.string("foo", { nullable: true }); },
+});`,
+      errors: ["The interfaceType Foo is missing a description"],
+    },
+
+    {
+      code: `import { inputObjectType } from "nexus";
+const Foo = inputObjectType({
+  name: "Foo",
+  definition(t) { t.string("foo", { nullable: true }); },
+});`,
+      errors: ["The inputObjectType Foo is missing a description"],
+    },
+
+    {
+      code: `import { enumType } from "nexus";
+const Foo = enumType({
+  name: "Foo",
+  members: ["BAR", "BAZ"],
+});`,
+      errors: ["The enumType Foo is missing a description"],
+    },
+  ],
+});

--- a/packages/eslint-plugin-wantedly/rules/nexus-type-description.js
+++ b/packages/eslint-plugin-wantedly/rules/nexus-type-description.js
@@ -1,0 +1,88 @@
+const { Linter } = require("eslint");
+const { docsUrl } = require("./utils");
+
+const linter = new Linter();
+const RULE_NAME = "nexus-type-description";
+
+const FUNCTION_WHITELIST = ["objectType", "unionType", "scalarType", "interfaceType", "inputObjectType", "enumType"];
+
+linter.defineRule(RULE_NAME, {
+  meta: {
+    type: "suggestion",
+    docs: {
+      url: docsUrl(RULE_NAME),
+    },
+  },
+  create(context) {
+    let isNexusUsed = false;
+
+    return {
+      ImportDeclaration(importDeclaration) {
+        if (
+          importDeclaration.source &&
+          importDeclaration.source.type === "Literal" &&
+          importDeclaration.source.value === "nexus"
+        ) {
+          isNexusUsed = true;
+        }
+      },
+
+      CallExpression(callExpression) {
+        if (!isNexusUsed) {
+          return;
+        }
+
+        const functionName = callExpression.callee.name;
+        if (!FUNCTION_WHITELIST.includes(functionName)) {
+          return;
+        }
+
+        const argumentDef = callExpression.arguments[0];
+        if (!argumentDef) {
+          return;
+        }
+
+        const nameProperty = argumentDef.properties.find(property => property.key.name === "name");
+        if (!nameProperty) {
+          return;
+        }
+
+        const typeName = nameProperty.value.value;
+        const descriptionProperty = argumentDef.properties.find(property => property.key.name === "description");
+
+        if (!descriptionProperty) {
+          return context.report({
+            node: callExpression,
+            message: "The {{functionName}} {{typeName}} is missing a description",
+            data: {
+              functionName,
+              typeName,
+            },
+          });
+        }
+
+        if (descriptionProperty.value.type !== "Literal") {
+          // We now support only string literal for description property
+          return;
+        }
+
+        const descriptionValue = descriptionProperty.value;
+        if (descriptionValue && descriptionValue.value.length === 0) {
+          return context.report({
+            node: callExpression,
+            message: "The {{functionName}} {{typeName}} is missing a description",
+            data: {
+              functionName,
+              typeName,
+            },
+          });
+        }
+      },
+    };
+  },
+});
+
+module.exports = {
+  RULE_NAME,
+  RULE: linter.getRules().get(RULE_NAME),
+};


### PR DESCRIPTION
## WHY & WHAT

Create `nexus-type-description` rule.

## Validate that the types have descriptions if the code using `nexus` (`wantedly/nexus-type-description`)

### Rule Details

#### Valid

```js
import { objectType } from "nexus";

const Foo = objectType({
  name: "Foo",
  definitions(t) {
    // define fields
  },
  description: "Foo represents the record of Foo",
});
```

#### Invalid

```js
import { objectType } from "nexus";

const Foo = objectType({
  name: "Foo",
  definitions(t) {
    // define fields
  },
  // missing description field or the description is empty string
});
```
