### PR TITLE
Fix exported eslintrc content

### DIFF
--- a/packages/frolint/src/commands/ExportCommand.ts
+++ b/packages/frolint/src/commands/ExportCommand.ts
@@ -19,11 +19,12 @@ export class ExportCommand extends Command<FrolintContext> {
       accessSync(eslintrcPath, constants.R_OK);
     } catch (err) {
       if (err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-        const eslintrcContent = `
-        {
-          "extends": ["wantedly-typescript"],
-        }
-        `;
+        const eslintrcContent = `{
+  "extends": ["wantedly-typescript"],
+  "parserOptions": {
+    "project": ["./tsconfig.json"]
+  }
+}`;
 
         writeFileSync(eslintrcPath, eslintrcContent);
       }


### PR DESCRIPTION
## WHY & WHAT

The content of `.eslintrc` which is written by the command `frolint export` is wrong.

```console
> cat .eslintrc

        {
          "extends": ["wantedly-typescript"],
        }
        
```

This content should be below.

```console
> cat .eslintrc
{
  "extends": ["wantedly-typescript"],
  "parserOptions": {
    "project": ["./tsconfig.json"]
  }
}
```