### PR TITLE
Create `nexus-enum-values-description` rule

### DIFF
--- a/packages/eslint-plugin-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-plugin-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -33,6 +33,16 @@ Object {
         "type": "suggestion",
       },
     },
+    "nexus-enum-values-description": Object {
+      "create": [Function],
+      "meta": Object {
+        "docs": Object {
+          "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/nexus-enum-values-description.md",
+        },
+        "fixable": "code",
+        "type": "suggestion",
+      },
+    },
     "nexus-pascal-case-type-name": Object {
       "create": [Function],
       "meta": Object {

--- a/packages/eslint-plugin-wantedly/docs/rules/nexus-enum-values-description.md
+++ b/packages/eslint-plugin-wantedly/docs/rules/nexus-enum-values-description.md
@@ -1,0 +1,35 @@
+# Enforce the each of the enum members has description (`wantedly/nexus-enum-values-description`)
+
+## Rule Details
+
+#### Valid
+
+```js
+import { enumType } from "nexus";
+
+export const CountryCode = enumType({
+  name: "CountryCode",
+  members: [
+    { name: "JP", description: "This represents Japan" },
+    { name: "US", description: "This represents United States" },
+    { name: "FR", description: "This represents France" },
+  ],
+});
+```
+
+#### Invalid
+
+```js
+import { enumType } from "nexus";
+
+export const CountryCode = enumType({
+  name: "CountryCode",
+  members: [
+    // invalid
+    "JP", // this is string literal, cannot include a description
+    { name: "US" }, // no description property
+    { name: "FR", description: "" }, // description is empty string
+    { name: "ES", description: "                     " }, // description is empty string
+  ],
+});
+```

--- a/packages/eslint-plugin-wantedly/docs/rules/nexus-enum-values-description.md
+++ b/packages/eslint-plugin-wantedly/docs/rules/nexus-enum-values-description.md
@@ -1,4 +1,4 @@
-# Enforce the each of the enum members has description (`wantedly/nexus-enum-values-description`)
+# Enforce each of the enum members has description (`wantedly/nexus-enum-values-description`)
 
 ## Rule Details
 

--- a/packages/eslint-plugin-wantedly/index.js
+++ b/packages/eslint-plugin-wantedly/index.js
@@ -1,6 +1,7 @@
 const graphqlOperationName = require("./rules/graphql-operation-name");
 const graphqlPascalCaseTypeName = require("./rules/graphql-pascal-case-type-name");
 const nexusCamelCaseFieldName = require("./rules/nexus-camel-case-field-name");
+const nexusEnumValuesDescription = require("./rules/nexus-enum-values-description");
 const nexusPascalCaseTypeName = require("./rules/nexus-pascal-case-type-name");
 const nexusTypeDescription = require("./rules/nexus-type-description");
 const nexusUpperCaseEnumMembers = require("./rules/nexus-upper-case-enum-members");
@@ -10,6 +11,7 @@ module.exports = {
     [graphqlOperationName.RULE_NAME]: graphqlOperationName.RULE,
     [graphqlPascalCaseTypeName.RULE_NAME]: graphqlPascalCaseTypeName.RULE,
     [nexusCamelCaseFieldName.RULE_NAME]: nexusCamelCaseFieldName.RULE,
+    [nexusEnumValuesDescription.RULE_NAME]: nexusEnumValuesDescription.RULE,
     [nexusPascalCaseTypeName.RULE_NAME]: nexusPascalCaseTypeName.RULE,
     [nexusTypeDescription.RULE_NAME]: nexusTypeDescription.RULE,
     [nexusUpperCaseEnumMembers.RULE_NAME]: nexusUpperCaseEnumMembers.RULE,

--- a/packages/eslint-plugin-wantedly/rules/__tests__/nexus-enum-values-description.test.js
+++ b/packages/eslint-plugin-wantedly/rules/__tests__/nexus-enum-values-description.test.js
@@ -1,0 +1,79 @@
+const RuleTester = require("eslint").RuleTester;
+const ESLintConfigWantedly = require("eslint-config-wantedly/without-react");
+const rule = require("../nexus-enum-values-description");
+
+RuleTester.setDefaultConfig({
+  parser: require.resolve(ESLintConfigWantedly.parser),
+  parserOptions: ESLintConfigWantedly.parserOptions,
+});
+
+const ruleTester = new RuleTester();
+ruleTester.run(rule.RULE_NAME, rule.RULE, {
+  valid: [],
+  invalid: [
+    {
+      code: `import { enumType } from "nexus";
+export const CountryCode = enumType({
+  name: "CountryCode",
+  members: [
+    { name: "JP", description: "This represents Japan" },
+    { name: "US" },
+    "CN",
+    { name: "FR", description: "" },
+    { name: "ES", description: "                     " },
+  ],
+});`,
+      errors: [
+        "The enum member `CountryCode.US` should have a description",
+        "The enum member `CountryCode.CN` should have a description",
+        "The enum member `CountryCode.FR` should have a description",
+        "The enum member `CountryCode.ES` should have a description",
+      ],
+    },
+    {
+      code: `import { enumType } from "nexus";
+export const CountryCode = enumType({
+  name: "CountryCode",
+  members: {
+    JP: 1,
+    US: 2,
+  },
+});`,
+      errors: [
+        "The enum definition `CountryCode` cannot specify the description for each enum member. You should use array expression for members property instead",
+      ],
+    },
+
+    {
+      code: `import { enumType } from "nexus";
+const members = [
+  { name: "JP", description: "This represents Japan" },
+  { name: "US" },
+  "CN",
+  { name: "FR", description: "" },
+  { name: "ES", description: "                     " },
+];
+export const CountryCode = enumType({
+  name: "CountryCode",
+  members,
+});`,
+      errors: [
+        "The enum member `CountryCode.US` should have a description",
+        "The enum member `CountryCode.CN` should have a description",
+        "The enum member `CountryCode.FR` should have a description",
+        "The enum member `CountryCode.ES` should have a description",
+      ],
+    },
+    {
+      code: `import { enumType } from "nexus";
+const members = { JP: 1, US: 2 };
+export const CountryCode = enumType({
+  name: "CountryCode",
+  members,
+});`,
+      errors: [
+        "The enum definition `CountryCode` cannot specify the description for each enum member. You should use array expression for members property instead",
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-wantedly/rules/nexus-enum-values-description.js
+++ b/packages/eslint-plugin-wantedly/rules/nexus-enum-values-description.js
@@ -1,0 +1,240 @@
+const { Linter } = require("eslint");
+const { docsUrl } = require("./utils");
+
+const linter = new Linter();
+const RULE_NAME = "nexus-enum-values-description";
+
+linter.defineRule(RULE_NAME, {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    docs: {
+      url: docsUrl(RULE_NAME),
+    },
+  },
+  create(context) {
+    let isNexusUsed = false;
+
+    return {
+      ImportDeclaration(importDeclaration) {
+        if (
+          importDeclaration.source &&
+          importDeclaration.source.type === "Literal" &&
+          importDeclaration.source.value === "nexus"
+        ) {
+          isNexusUsed = true;
+        } else {
+          return;
+        }
+      },
+
+      Property(node) {
+        if (!isNexusUsed) {
+          return;
+        }
+
+        if (node.key.name !== "members") {
+          return;
+        }
+
+        if (!node.parent) {
+          return;
+        }
+
+        const nameProperty = node.parent.properties.find(property => property.key.name === "name");
+        if (!nameProperty) {
+          return;
+        }
+        const enumName = nameProperty.value.value;
+
+        if (node.value.type === "ArrayExpression") {
+          const elements = node.value.elements;
+          elements.forEach(elem => {
+            if (elem.type === "Literal") {
+              if (!elem.value) {
+                return;
+              }
+
+              return context.report({
+                node: elem,
+                message: "The enum member `{{enumName}}.{{value}}` should have a description",
+                data: {
+                  enumName,
+                  value: elem.value,
+                },
+              });
+            }
+
+            if (elem.type === "ObjectExpression") {
+              const properties = elem.properties;
+              const nameProperty = properties.find(property => property.key.name === "name");
+              if (!nameProperty) {
+                return;
+              }
+
+              const descriptionProperty = properties.find(property => property.key.name === "description");
+              if (!descriptionProperty) {
+                return context.report({
+                  node: elem,
+                  message: "The enum member `{{enumName}}.{{value}}` should have a description",
+                  data: {
+                    enumName,
+                    value: nameProperty.value.value,
+                  },
+                });
+              }
+
+              if (descriptionProperty.value.type !== "Literal") {
+                // We now support only string literal for description property
+                return;
+              }
+
+              const descriptionValue = descriptionProperty.value;
+              if (
+                descriptionValue &&
+                typeof descriptionValue.value === "string" &&
+                descriptionValue.value.trim().length === 0
+              ) {
+                return context.report({
+                  node: elem,
+                  message: "The enum member `{{enumName}}.{{value}}` should have a description",
+                  data: {
+                    enumName,
+                    value: nameProperty.value.value,
+                  },
+                });
+              }
+            }
+          });
+
+          return;
+        }
+
+        if (node.value.type === "ObjectExpression") {
+          return context.report({
+            node: node.value,
+            message:
+              "The enum definition `{{enumName}}` cannot specify the description for each enum member. You should use array expression for members property instead",
+            data: {
+              enumName,
+            },
+          });
+        }
+
+        if (node.value.type === "Identifier") {
+          const membersVariableName = node.value.name;
+          const sourceCode = context.getSourceCode();
+          const tokensAndComments = sourceCode.tokensAndComments;
+          if (!Array.isArray(tokensAndComments)) {
+            return;
+          }
+
+          const maybeToken = tokensAndComments.find(
+            token => token.type === "Identifier" && token.value === membersVariableName
+          );
+          if (!maybeToken) {
+            return;
+          }
+
+          const tokenStartIndex = maybeToken.start || maybeToken.range[0];
+          const maybeNode = sourceCode.getNodeByRangeIndex(tokenStartIndex);
+          if (!maybeNode) {
+            return;
+          }
+
+          const parent = maybeNode.parent;
+          if (!parent || parent.type !== "VariableDeclarator" || !parent.init) {
+            return;
+          }
+
+          if (parent.init.type === "ArrayExpression") {
+            /**
+             * In this case, the variable is array
+             * e.g. const members = ["foo", "bar"]
+             */
+            const elements = parent.init.elements;
+            elements.forEach(elem => {
+              if (elem.type === "Literal") {
+                if (!elem.value) {
+                  return;
+                }
+
+                return context.report({
+                  node: elem,
+                  message: "The enum member `{{enumName}}.{{value}}` should have a description",
+                  data: {
+                    enumName,
+                    value: elem.value,
+                  },
+                });
+              }
+
+              if (elem.type === "ObjectExpression") {
+                const properties = elem.properties;
+                const nameProperty = properties.find(property => property.key.name === "name");
+                if (!nameProperty) {
+                  return;
+                }
+
+                const descriptionProperty = properties.find(property => property.key.name === "description");
+                if (!descriptionProperty) {
+                  return context.report({
+                    node: elem,
+                    message: "The enum member `{{enumName}}.{{value}}` should have a description",
+                    data: {
+                      enumName,
+                      value: nameProperty.value.value,
+                    },
+                  });
+                }
+
+                if (descriptionProperty.value.type !== "Literal") {
+                  // We now support only string literal for description property
+                  return;
+                }
+
+                const descriptionValue = descriptionProperty.value;
+                if (
+                  descriptionValue &&
+                  typeof descriptionValue.value === "string" &&
+                  descriptionValue.value.trim().length === 0
+                ) {
+                  return context.report({
+                    node: elem,
+                    message: "The enum member `{{enumName}}.{{value}}` should have a description",
+                    data: {
+                      enumName,
+                      value: nameProperty.value.value,
+                    },
+                  });
+                }
+              }
+            });
+
+            return;
+          } else if (parent.init.type === "ObjectExpression") {
+            /**
+             * In this case, the variable is object
+             * e.g. const members = { foo: 1, bar: 2 }
+             */
+            return context.report({
+              node: node.value,
+              message:
+                "The enum definition `{{enumName}}` cannot specify the description for each enum member. You should use array expression for members property instead",
+              data: {
+                enumName,
+              },
+            });
+          }
+
+          return;
+        }
+      },
+    };
+  },
+});
+
+module.exports = {
+  RULE_NAME,
+  RULE: linter.getRules().get(RULE_NAME),
+};

--- a/packages/eslint-plugin-wantedly/rules/nexus-type-description.js
+++ b/packages/eslint-plugin-wantedly/rules/nexus-type-description.js
@@ -69,7 +69,7 @@ linter.defineRule(RULE_NAME, {
         }
 
         const descriptionValue = descriptionProperty.value;
-        if (descriptionValue && descriptionValue.value.length === 0) {
+        if (descriptionValue && descriptionValue.value.trim().length === 0) {
           return context.report({
             node: callExpression,
             message: "The {{functionName}} {{typeName}} is missing a description",


### PR DESCRIPTION
## WHY & WHAT

Create `nexus-enum-values-description` rule to enforce each of the enum members has description

### Rule Details

#### Valid

```js
import { enumType } from "nexus";
export const CountryCode = enumType({
  name: "CountryCode",
  members: [
    { name: "JP", description: "This represents Japan" },
    { name: "US", description: "This represents United States" },
    { name: "FR", description: "This represents France" },
  ],
});
```

#### Invalid

```js
import { enumType } from "nexus";
export const CountryCode = enumType({
  name: "CountryCode",
  members: [
    // invalid
    "JP", // this is string literal, cannot include a description
    { name: "US" }, // no description property
    { name: "FR", description: "" }, // description is empty string
    { name: "ES", description: "                     " }, // description is empty string
  ],
});
```
