### PR TITLE
Create nexus-field-description rule

### DIFF
--- a/.scaffdog/eslint-plugin-wantedly-rule.md
+++ b/.scaffdog/eslint-plugin-wantedly-rule.md
@@ -31,6 +31,7 @@ linter.defineRule(RULE_NAME, {
   },
   create(context) {
     // Code fun !!
+    return {};
   },
 });
 

--- a/packages/eslint-plugin-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-plugin-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -43,6 +43,16 @@ Object {
         "type": "suggestion",
       },
     },
+    "nexus-field-description": Object {
+      "create": [Function],
+      "meta": Object {
+        "docs": Object {
+          "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/nexus-field-description.md",
+        },
+        "fixable": "code",
+        "type": "suggestion",
+      },
+    },
     "nexus-pascal-case-type-name": Object {
       "create": [Function],
       "meta": Object {

--- a/packages/eslint-plugin-wantedly/docs/rules/nexus-field-description.md
+++ b/packages/eslint-plugin-wantedly/docs/rules/nexus-field-description.md
@@ -1,7 +1,33 @@
-# Short description here (`wantedly/nexus-field-description`)
+# Validate that the fields have descriptions if the code using `nexus` (`wantedly/nexus-field-description`)
 
 ## Rule Details
 
 #### Valid
 
+```js
+import { objectType } from "nexus";
+
+const User = objectType({
+  name: "User",
+  definition(t) {
+    t.id("id", { nullable: false, description: "Represents the Object Global Identification" });
+  },
+});
+```
+
 #### Invalid
+
+```js
+import { objectType } from "nexus";
+
+const User = objectType({
+  name: "User",
+  definition(t) {
+    // invalid
+    t.string("fullName"); // this cannot include a description in second parameter
+    t.int("age", { nullable: true }); // no description property
+    t.boolean("isAdmin", { nullable: false, description: "" }); // description is an empty string
+    t.id("id", { nullable: false, description: "          " }); // description is an empty string
+  },
+});
+```

--- a/packages/eslint-plugin-wantedly/docs/rules/nexus-field-description.md
+++ b/packages/eslint-plugin-wantedly/docs/rules/nexus-field-description.md
@@ -1,0 +1,7 @@
+# Short description here (`wantedly/nexus-field-description`)
+
+## Rule Details
+
+#### Valid
+
+#### Invalid

--- a/packages/eslint-plugin-wantedly/index.js
+++ b/packages/eslint-plugin-wantedly/index.js
@@ -2,6 +2,7 @@ const graphqlOperationName = require("./rules/graphql-operation-name");
 const graphqlPascalCaseTypeName = require("./rules/graphql-pascal-case-type-name");
 const nexusCamelCaseFieldName = require("./rules/nexus-camel-case-field-name");
 const nexusEnumValuesDescription = require("./rules/nexus-enum-values-description");
+const nexusFieldDescription = require("./rules/nexus-field-description");
 const nexusPascalCaseTypeName = require("./rules/nexus-pascal-case-type-name");
 const nexusTypeDescription = require("./rules/nexus-type-description");
 const nexusUpperCaseEnumMembers = require("./rules/nexus-upper-case-enum-members");
@@ -12,6 +13,7 @@ module.exports = {
     [graphqlPascalCaseTypeName.RULE_NAME]: graphqlPascalCaseTypeName.RULE,
     [nexusCamelCaseFieldName.RULE_NAME]: nexusCamelCaseFieldName.RULE,
     [nexusEnumValuesDescription.RULE_NAME]: nexusEnumValuesDescription.RULE,
+    [nexusFieldDescription.RULE_NAME]: nexusFieldDescription.RULE,
     [nexusPascalCaseTypeName.RULE_NAME]: nexusPascalCaseTypeName.RULE,
     [nexusTypeDescription.RULE_NAME]: nexusTypeDescription.RULE,
     [nexusUpperCaseEnumMembers.RULE_NAME]: nexusUpperCaseEnumMembers.RULE,

--- a/packages/eslint-plugin-wantedly/rules/__tests__/nexus-field-description.test.js
+++ b/packages/eslint-plugin-wantedly/rules/__tests__/nexus-field-description.test.js
@@ -1,0 +1,39 @@
+const RuleTester = require("eslint").RuleTester;
+const ESLintConfigWantedly = require("eslint-config-wantedly/without-react");
+const rule = require("../nexus-field-description");
+
+RuleTester.setDefaultConfig({
+  parser: require.resolve(ESLintConfigWantedly.parser),
+  parserOptions: ESLintConfigWantedly.parserOptions,
+});
+
+const ruleTester = new RuleTester();
+ruleTester.run(rule.RULE_NAME, rule.RULE, {
+  valid: [],
+  invalid: [
+    {
+      code: `import { objectType } from "nexus";
+const User = objectType({
+  name: "User",
+  definition(t) {
+    t.string("fullName");
+    t.int("age", { nullable: true });
+    t.boolean("isAdmin", { nullable: false, description: "" });
+    t.id("id", { nullable: false, description: "     " });
+    t.float("motivation", { nullable: true });
+    t.field("profile", { nullable: false });
+    t.list.field("posts", { nullable: false });
+  },
+});`,
+      errors: [
+        "The field fullName should have a description",
+        "The field age should have a description",
+        "The field isAdmin should have a description",
+        "The field id should have a description",
+        "The field motivation should have a description",
+        "The field profile should have a description",
+        "The field posts should have a description",
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-wantedly/rules/nexus-field-description.js
+++ b/packages/eslint-plugin-wantedly/rules/nexus-field-description.js
@@ -1,0 +1,113 @@
+const { Linter } = require("eslint");
+const { docsUrl } = require("./utils");
+
+const linter = new Linter();
+const RULE_NAME = "nexus-field-description";
+
+const WHITELIST_FOR_TYPE_DEFINITION = ["objectType", "interfaceType", "inputObjectType"];
+const FIELD_DEFINITION_METHODS = ["string", "int", "boolean", "id", "float", "field"];
+
+linter.defineRule(RULE_NAME, {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    docs: {
+      url: docsUrl(RULE_NAME),
+    },
+  },
+  create(context) {
+    let isNexusUsed = false;
+
+    return {
+      ImportDeclaration(importDeclaration) {
+        if (
+          importDeclaration.source &&
+          importDeclaration.source.type === "Literal" &&
+          importDeclaration.source.value === "nexus"
+        ) {
+          isNexusUsed = true;
+        } else {
+          return;
+        }
+      },
+
+      CallExpression(callExpression) {
+        if (!isNexusUsed) {
+          return;
+        }
+
+        const callee = callExpression.callee;
+        if (callee.type !== "Identifier" || !WHITELIST_FOR_TYPE_DEFINITION.includes(callee.name)) {
+          return;
+        }
+
+        const argument = callExpression.arguments[0];
+        if (!argument || argument.type !== "ObjectExpression" || argument.properties.length <= 0) {
+          return;
+        }
+
+        const definitionProperty = argument.properties.find(
+          property => property.key && property.key.type === "Identifier" && property.key.name === "definition"
+        );
+        const definitions = definitionProperty.value.body.body;
+
+        definitions.forEach(expressionStatement => {
+          if (!FIELD_DEFINITION_METHODS.includes(expressionStatement.expression.callee.property.name)) {
+            return;
+          }
+
+          const fieldNameNode = expressionStatement.expression.arguments[0];
+          if (!fieldNameNode) {
+            return;
+          }
+
+          const fieldName = fieldNameNode.value;
+          const fieldConfigNode = expressionStatement.expression.arguments[1]; // ObjectExpression
+          if (!fieldConfigNode) {
+            return context.report({
+              node: callExpression,
+              message: "The field {{fieldName}} should have a description",
+              data: {
+                fieldName,
+              },
+            });
+          }
+
+          const descriptionProperty = fieldConfigNode.properties.find(
+            property => property.key && property.key.type === "Identifier" && property.key.name === "description"
+          );
+          if (!descriptionProperty) {
+            return context.report({
+              node: callExpression,
+              message: "The field {{fieldName}} should have a description",
+              data: {
+                fieldName,
+              },
+            });
+          }
+
+          if (descriptionProperty.value.type !== "Literal") {
+            // We now support only string literal for description property
+            return;
+          }
+
+          const descriptionValue = descriptionProperty.value;
+          if (descriptionValue && descriptionValue.value.trim().length === 0) {
+            return context.report({
+              node: callExpression,
+              message: "The field {{fieldName}} should have a description",
+              data: {
+                fieldName,
+              },
+            });
+          }
+        });
+      },
+    };
+  },
+});
+
+module.exports = {
+  RULE_NAME,
+  RULE: linter.getRules().get(RULE_NAME),
+};


### PR DESCRIPTION
## WHY & WHAT

## Validate that the fields have descriptions if the code using `nexus` (`wantedly/nexus-field-description`)

### Rule Details

#### Valid

```js
import { objectType } from "nexus";

const User = objectType({
  name: "User",
  definition(t) {
    t.id("id", { nullable: false, description: "Represents the Object Global Identification" });
  },
});
```

#### Invalid

```js
import { objectType } from "nexus";

const User = objectType({
  name: "User",
  definition(t) {
    // invalid
    t.string("fullName"); // this cannot include a description in second parameter
    t.int("age", { nullable: true }); // no description property
    t.boolean("isAdmin", { nullable: false, description: "" }); // description is an empty string
    t.id("id", { nullable: false, description: "          " }); // description is an empty string
  },
});
```
