### PR TITLE
Do not use **/*

### DIFF
--- a/packages/frolint/src/utils/git.ts
+++ b/packages/frolint/src/utils/git.ts
@@ -96,9 +96,7 @@ export function getAllFiles(isTypeScript: boolean, rootDir: string) {
     return [];
   }
 
-  const extensions = (isTypeScript ? [".js", ".jsx", ".ts", ".tsx"] : [".js", ".jsx"])
-    .map(ext => `"**/*${ext}"`)
-    .join(" ");
+  const extensions = (isTypeScript ? ["*.js", "*.jsx", "*.ts", "*.tsx"] : ["*.js", "*.jsx"]).join(" ");
 
   return execSync(`git ls-files ${extensions}`, { cwd: rootDir })
     .toString()


### PR DESCRIPTION
## WHY & WHAT

`frolint` cannot lint and format files in the project root.

cc. @chloe463 