### PR TITLE
Use `arrow-parens` rule option as `always`

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -192,7 +192,7 @@ Object {
   ],
   "arrow-parens": Array [
     "warn",
-    "as-needed",
+    "always",
   ],
   "arrow-spacing": Array [
     "off",

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
@@ -190,7 +190,7 @@ Object {
   ],
   "arrow-parens": Array [
     "warn",
-    "as-needed",
+    "always",
   ],
   "arrow-spacing": Array [
     "off",

--- a/packages/eslint-config-wantedly-typescript/without-react.js
+++ b/packages/eslint-config-wantedly-typescript/without-react.js
@@ -21,7 +21,7 @@ module.exports = {
   rules: {
     "array-callback-return": "off",
     "arrow-body-style": ["off"],
-    "arrow-parens": ["warn", "as-needed"],
+    "arrow-parens": ["warn", "always"],
     "class-methods-use-this": "off",
     "comma-dangle": [
       "error",

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -64,7 +64,7 @@ Object {
   ],
   "arrow-parens": Array [
     "warn",
-    "as-needed",
+    "always",
   ],
   "arrow-spacing": Array [
     "off",

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
@@ -62,7 +62,7 @@ Object {
   ],
   "arrow-parens": Array [
     "warn",
-    "as-needed",
+    "always",
   ],
   "arrow-spacing": Array [
     "off",

--- a/packages/eslint-config-wantedly/without-react.js
+++ b/packages/eslint-config-wantedly/without-react.js
@@ -21,7 +21,7 @@ module.exports = {
   rules: {
     "array-callback-return": "off",
     "arrow-body-style": ["off"],
-    "arrow-parens": ["warn", "as-needed"],
+    "arrow-parens": ["warn", "always"],
     "class-methods-use-this": "off",
     "comma-dangle": [
       "error",


### PR DESCRIPTION
## WHY & WHAT

https://prettier.io/blog/2020/03/21/2.0.0.html#change-default-value-for-arrowparens-to-always-7430httpsgithubcomprettierprettierpull7430-by-kachkaevhttpsgithubcomkachkaev

Now Prettier changes the `arrowParens` default value to `always`.