### PR TITLE
Add `--bail` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:watch:frolint": "lerna exec \"npm run test -- --watch\" --scope frolint",
     "test:update": "lerna run --parallel test -- -u",
     "lint": "frolint --branch master",
-    "lint:ci": "frolint",
+    "lint:ci": "frolint --bail",
     "changelog": "yarn lerna-changelog",
     "build": "lerna run build --scope frolint",
     "build:watch": "lerna exec npm run build:watch --scope frolint",

--- a/packages/eslint-config-wantedly-typescript/__tests__/index.test.js
+++ b/packages/eslint-config-wantedly-typescript/__tests__/index.test.js
@@ -7,7 +7,7 @@ const engine = new CLIEngine({
   useEslintrc: false,
 });
 
-const normalizePath = path => {
+const normalizePath = (path) => {
   return /node_modules/.test(path) ? path.split("node_modules")[1] : path;
 };
 
@@ -17,7 +17,7 @@ describe("eslint-config-wantedly-typescript", () => {
 
   beforeAll(() => {
     const normalizeRequiredKeys = ["extends", "parser"];
-    normalizeRequiredKeys.forEach(key => {
+    normalizeRequiredKeys.forEach((key) => {
       const newConfig = config[key];
 
       if (Array.isArray(newConfig)) {
@@ -28,7 +28,7 @@ describe("eslint-config-wantedly-typescript", () => {
     });
   });
 
-  keys.forEach(key => {
+  keys.forEach((key) => {
     test(`should match snapshot for ${key}`, () => {
       expect(config[key]).toMatchSnapshot();
     });

--- a/packages/eslint-config-wantedly-typescript/__tests__/without-react.test.js
+++ b/packages/eslint-config-wantedly-typescript/__tests__/without-react.test.js
@@ -7,7 +7,7 @@ const engine = new CLIEngine({
   useEslintrc: false,
 });
 
-const normalizePath = path => {
+const normalizePath = (path) => {
   return /node_modules/.test(path) ? path.split("node_modules")[1] : path;
 };
 
@@ -17,7 +17,7 @@ describe("eslint-config-wantedly-typescript/without-react", () => {
 
   beforeAll(() => {
     const normalizeRequiredKeys = ["extends", "parser"];
-    normalizeRequiredKeys.forEach(key => {
+    normalizeRequiredKeys.forEach((key) => {
       const newConfig = config[key];
 
       if (Array.isArray(newConfig)) {
@@ -28,7 +28,7 @@ describe("eslint-config-wantedly-typescript/without-react", () => {
     });
   });
 
-  keys.forEach(key => {
+  keys.forEach((key) => {
     test(`should match snapshot for ${key}`, () => {
       expect(config[key]).toMatchSnapshot();
     });

--- a/packages/eslint-config-wantedly/__tests__/index.test.js
+++ b/packages/eslint-config-wantedly/__tests__/index.test.js
@@ -7,7 +7,7 @@ const engine = new CLIEngine({
   useEslintrc: false,
 });
 
-const normalizePath = path => {
+const normalizePath = (path) => {
   return /node_modules/.test(path) ? path.split("node_modules")[1] : path;
 };
 
@@ -17,7 +17,7 @@ describe("eslint-config-wantedly", () => {
 
   beforeAll(() => {
     const normalizeRequiredKeys = ["extends", "parser"];
-    normalizeRequiredKeys.forEach(key => {
+    normalizeRequiredKeys.forEach((key) => {
       const newConfig = config[key];
 
       if (Array.isArray(newConfig)) {
@@ -28,7 +28,7 @@ describe("eslint-config-wantedly", () => {
     });
   });
 
-  keys.forEach(key => {
+  keys.forEach((key) => {
     test(`should match snapshot for ${key}`, () => {
       expect(config[key]).toMatchSnapshot();
     });

--- a/packages/eslint-config-wantedly/__tests__/without-react.test.js
+++ b/packages/eslint-config-wantedly/__tests__/without-react.test.js
@@ -7,7 +7,7 @@ const engine = new CLIEngine({
   useEslintrc: false,
 });
 
-const normalizePath = path => {
+const normalizePath = (path) => {
   return /node_modules/.test(path) ? path.split("node_modules")[1] : path;
 };
 
@@ -17,7 +17,7 @@ describe("eslint-config-wantedly/without-react", () => {
 
   beforeAll(() => {
     const normalizeRequiredKeys = ["extends", "parser"];
-    normalizeRequiredKeys.forEach(key => {
+    normalizeRequiredKeys.forEach((key) => {
       const newConfig = config[key];
 
       if (Array.isArray(newConfig)) {
@@ -28,7 +28,7 @@ describe("eslint-config-wantedly/without-react", () => {
     });
   });
 
-  keys.forEach(key => {
+  keys.forEach((key) => {
     test(`should match snapshot for ${key}`, () => {
       expect(config[key]).toMatchSnapshot();
     });

--- a/packages/eslint-plugin-use-macros/createUseMacro.js
+++ b/packages/eslint-plugin-use-macros/createUseMacro.js
@@ -16,7 +16,7 @@ module.exports = function createUseMacro(from, to, context) {
     TARGET_LIBRARY_INSTALLED = false;
   }
 
-  return function(node) {
+  return function (node) {
     const importName = node.source.value.trim();
 
     if (importName === from) {

--- a/packages/eslint-plugin-wantedly/rules/nexus-camel-case-field-name.js
+++ b/packages/eslint-plugin-wantedly/rules/nexus-camel-case-field-name.js
@@ -55,11 +55,11 @@ linter.defineRule(RULE_NAME, {
         }
 
         const definitionProperty = argument.properties.find(
-          property => property.key && property.key.type === "Identifier" && property.key.name === "definition"
+          (property) => property.key && property.key.type === "Identifier" && property.key.name === "definition"
         );
         const definitions = definitionProperty.value.body.body;
 
-        definitions.forEach(expressionStatement => {
+        definitions.forEach((expressionStatement) => {
           if (
             !expressionStatement.expression ||
             !expressionStatement.expression.callee ||

--- a/packages/eslint-plugin-wantedly/rules/nexus-enum-values-description.js
+++ b/packages/eslint-plugin-wantedly/rules/nexus-enum-values-description.js
@@ -41,7 +41,7 @@ linter.defineRule(RULE_NAME, {
           return;
         }
 
-        const nameProperty = node.parent.properties.find(property => property.key.name === "name");
+        const nameProperty = node.parent.properties.find((property) => property.key.name === "name");
         if (!nameProperty) {
           return;
         }
@@ -49,7 +49,7 @@ linter.defineRule(RULE_NAME, {
 
         if (node.value.type === "ArrayExpression") {
           const elements = node.value.elements;
-          elements.forEach(elem => {
+          elements.forEach((elem) => {
             if (elem.type === "Literal") {
               if (!elem.value) {
                 return;
@@ -67,12 +67,12 @@ linter.defineRule(RULE_NAME, {
 
             if (elem.type === "ObjectExpression") {
               const properties = elem.properties;
-              const nameProperty = properties.find(property => property.key.name === "name");
+              const nameProperty = properties.find((property) => property.key.name === "name");
               if (!nameProperty) {
                 return;
               }
 
-              const descriptionProperty = properties.find(property => property.key.name === "description");
+              const descriptionProperty = properties.find((property) => property.key.name === "description");
               if (!descriptionProperty) {
                 return context.report({
                   node: elem,
@@ -130,7 +130,7 @@ linter.defineRule(RULE_NAME, {
           }
 
           const maybeToken = tokensAndComments.find(
-            token => token.type === "Identifier" && token.value === membersVariableName
+            (token) => token.type === "Identifier" && token.value === membersVariableName
           );
           if (!maybeToken) {
             return;
@@ -153,7 +153,7 @@ linter.defineRule(RULE_NAME, {
              * e.g. const members = ["foo", "bar"]
              */
             const elements = parent.init.elements;
-            elements.forEach(elem => {
+            elements.forEach((elem) => {
               if (elem.type === "Literal") {
                 if (!elem.value) {
                   return;
@@ -171,12 +171,12 @@ linter.defineRule(RULE_NAME, {
 
               if (elem.type === "ObjectExpression") {
                 const properties = elem.properties;
-                const nameProperty = properties.find(property => property.key.name === "name");
+                const nameProperty = properties.find((property) => property.key.name === "name");
                 if (!nameProperty) {
                   return;
                 }
 
-                const descriptionProperty = properties.find(property => property.key.name === "description");
+                const descriptionProperty = properties.find((property) => property.key.name === "description");
                 if (!descriptionProperty) {
                   return context.report({
                     node: elem,

--- a/packages/eslint-plugin-wantedly/rules/nexus-field-description.js
+++ b/packages/eslint-plugin-wantedly/rules/nexus-field-description.js
@@ -47,11 +47,11 @@ linter.defineRule(RULE_NAME, {
         }
 
         const definitionProperty = argument.properties.find(
-          property => property.key && property.key.type === "Identifier" && property.key.name === "definition"
+          (property) => property.key && property.key.type === "Identifier" && property.key.name === "definition"
         );
         const definitions = definitionProperty.value.body.body;
 
-        definitions.forEach(expressionStatement => {
+        definitions.forEach((expressionStatement) => {
           if (!FIELD_DEFINITION_METHODS.includes(expressionStatement.expression.callee.property.name)) {
             return;
           }
@@ -74,7 +74,7 @@ linter.defineRule(RULE_NAME, {
           }
 
           const descriptionProperty = fieldConfigNode.properties.find(
-            property => property.key && property.key.type === "Identifier" && property.key.name === "description"
+            (property) => property.key && property.key.type === "Identifier" && property.key.name === "description"
           );
           if (!descriptionProperty) {
             return context.report({

--- a/packages/eslint-plugin-wantedly/rules/nexus-pascal-case-type-name.js
+++ b/packages/eslint-plugin-wantedly/rules/nexus-pascal-case-type-name.js
@@ -50,7 +50,7 @@ linter.defineRule(RULE_NAME, {
         }
 
         const argumentDef = callExpression.arguments[0];
-        const targetNode = argumentDef.properties.find(property => property.key.name === "name").value;
+        const targetNode = argumentDef.properties.find((property) => property.key.name === "name").value;
         // If the value is template literal string, this line raises error
         const typeName = targetNode.value;
         const pascalCased = pascalCase(typeName);

--- a/packages/eslint-plugin-wantedly/rules/nexus-type-description.js
+++ b/packages/eslint-plugin-wantedly/rules/nexus-type-description.js
@@ -45,13 +45,13 @@ linter.defineRule(RULE_NAME, {
           return;
         }
 
-        const nameProperty = argumentDef.properties.find(property => property.key.name === "name");
+        const nameProperty = argumentDef.properties.find((property) => property.key.name === "name");
         if (!nameProperty) {
           return;
         }
 
         const typeName = nameProperty.value.value;
-        const descriptionProperty = argumentDef.properties.find(property => property.key.name === "description");
+        const descriptionProperty = argumentDef.properties.find((property) => property.key.name === "description");
 
         if (!descriptionProperty) {
           return context.report({

--- a/packages/eslint-plugin-wantedly/rules/nexus-upper-case-enum-members.js
+++ b/packages/eslint-plugin-wantedly/rules/nexus-upper-case-enum-members.js
@@ -49,7 +49,7 @@ linter.defineRule(RULE_NAME, {
           return;
         }
 
-        const nameProperty = node.parent.properties.find(property => property.key.name === "name");
+        const nameProperty = node.parent.properties.find((property) => property.key.name === "name");
         if (!nameProperty) {
           return;
         }
@@ -57,7 +57,7 @@ linter.defineRule(RULE_NAME, {
 
         if (node.value.type === "ArrayExpression") {
           const elements = node.value.elements;
-          elements.forEach(elem => {
+          elements.forEach((elem) => {
             if (elem.type === "Literal") {
               const value = elem.value || "";
               const upperCased = snakeCase(value).toUpperCase();
@@ -84,7 +84,7 @@ linter.defineRule(RULE_NAME, {
 
             if (elem.type === "ObjectExpression") {
               const properties = elem.properties;
-              const nameProperty = properties.find(property => property.key.name === "name");
+              const nameProperty = properties.find((property) => property.key.name === "name");
               if (!nameProperty || nameProperty.value.type !== "Literal") {
                 return;
               }
@@ -118,7 +118,7 @@ linter.defineRule(RULE_NAME, {
 
         if (node.value.type === "ObjectExpression") {
           const properties = node.value.properties;
-          properties.forEach(property => {
+          properties.forEach((property) => {
             const keyName = property.key.name || "";
             const upperCased = snakeCase(keyName).toUpperCase();
 
@@ -157,7 +157,7 @@ linter.defineRule(RULE_NAME, {
           }
 
           const maybeToken = tokensAndComments.find(
-            token => token.type === "Identifier" && token.value === membersVariableName
+            (token) => token.type === "Identifier" && token.value === membersVariableName
           );
           if (!maybeToken) {
             return;
@@ -180,7 +180,7 @@ linter.defineRule(RULE_NAME, {
              * e.g. const members = ["foo", "bar"]
              */
             const elements = parent.init.elements;
-            elements.forEach(elem => {
+            elements.forEach((elem) => {
               if (elem.type !== "Literal") {
                 return;
               }
@@ -213,7 +213,7 @@ linter.defineRule(RULE_NAME, {
              * e.g. const members = { foo: 1, bar: 2 }
              */
             const properties = parent.init.properties;
-            properties.forEach(property => {
+            properties.forEach((property) => {
               const keyName = property.key.name || "";
               const upperCased = snakeCase(keyName).toUpperCase();
 

--- a/packages/frolint/src/commands/UninstallCommand.ts
+++ b/packages/frolint/src/commands/UninstallCommand.ts
@@ -36,7 +36,7 @@ export class UninstallCommand extends Command<FrolintContext> {
       const newContent: string[] = [];
       const lines = content.split("\n");
       let ignore = false;
-      lines.forEach(line => {
+      lines.forEach((line) => {
         if (line === START_COMMENT) {
           ignore = true;
         }

--- a/packages/frolint/src/utils/eslint.ts
+++ b/packages/frolint/src/utils/eslint.ts
@@ -53,5 +53,5 @@ export function applyEslint(
   eslintConfig: FrolintConfig["eslint"]
 ) {
   const cli = getCLI(rootDir, eslintConfigPackage, eslintConfig);
-  return cli.executeOnFiles(files.filter(isSupportedExtension).filter(file => !cli.isPathIgnored(file)));
+  return cli.executeOnFiles(files.filter(isSupportedExtension).filter((file) => !cli.isPathIgnored(file)));
 }

--- a/packages/frolint/src/utils/git.ts
+++ b/packages/frolint/src/utils/git.ts
@@ -6,9 +6,7 @@ import { END_COMMENT, START_COMMENT } from "./constants";
 
 export function isInsideGitRepository(cwd?: string) {
   try {
-    const res = execSync("git rev-parse --is-inside-work-tree", { cwd })
-      .toString()
-      .trim();
+    const res = execSync("git rev-parse --is-inside-work-tree", { cwd }).toString().trim();
     return res === "true";
   } catch (err) {
     return false;
@@ -20,12 +18,7 @@ export function isGitExist() {
 }
 
 export function getPreCommitHookPath(cwd?: string): string {
-  return resolve(
-    execSync("git rev-parse --git-path hooks", { cwd })
-      .toString()
-      .trim(),
-    "pre-commit"
-  );
+  return resolve(execSync("git rev-parse --git-path hooks", { cwd }).toString().trim(), "pre-commit");
 }
 
 export function isPreCommitHookInstalled() {
@@ -43,12 +36,7 @@ export function getGitRootDir(cwd: string) {
   }
 
   try {
-    return resolve(
-      cwd,
-      execSync("git rev-parse --show-cdup")
-        .toString()
-        .trimRight()
-    );
+    return resolve(cwd, execSync("git rev-parse --show-cdup").toString().trimRight());
   } catch (err) {
     return cwd;
   }
@@ -70,10 +58,7 @@ export function getUnstagedFiles(rootDir: string) {
     return [];
   }
 
-  return execSync("git diff --name-only --diff-filter=ACMRTUB", { cwd: rootDir })
-    .toString()
-    .trim()
-    .split("\n");
+  return execSync("git diff --name-only --diff-filter=ACMRTUB", { cwd: rootDir }).toString().trim().split("\n");
 }
 
 export function getChangedFilesFromBranch(branch: string, rootDir: string) {
@@ -81,9 +66,7 @@ export function getChangedFilesFromBranch(branch: string, rootDir: string) {
     return [];
   }
 
-  const commitHash = execSync(`git show-branch --merge-base ${branch} HEAD`, { cwd: rootDir })
-    .toString()
-    .trim();
+  const commitHash = execSync(`git show-branch --merge-base ${branch} HEAD`, { cwd: rootDir }).toString().trim();
 
   return execSync(`git diff --name-only --diff-filter=ACMRTUB ${commitHash}`, { cwd: rootDir })
     .toString()
@@ -98,10 +81,7 @@ export function getAllFiles(isTypeScript: boolean, rootDir: string) {
 
   const extensions = (isTypeScript ? ["*.js", "*.jsx", "*.ts", "*.tsx"] : ["*.js", "*.jsx"]).join(" ");
 
-  return execSync(`git ls-files ${extensions}`, { cwd: rootDir })
-    .toString()
-    .trim()
-    .split("\n");
+  return execSync(`git ls-files ${extensions}`, { cwd: rootDir }).toString().trim().split("\n");
 }
 
 export function stageFiles(files: string[], rootDir: string) {

--- a/packages/frolint/src/utils/prettier.ts
+++ b/packages/frolint/src/utils/prettier.ts
@@ -19,7 +19,7 @@ const supportedLanguages = [
 
 const supportedExtensions = prettier
   .getSupportInfo()
-  .languages.filter(lang => supportedLanguages.includes(lang.name))
+  .languages.filter((lang) => supportedLanguages.includes(lang.name))
   .reduce((acc, lang) => acc.concat(lang.extensions || []), [] as string[]);
 
 function isPrettierSupported(file: string) {
@@ -36,9 +36,9 @@ function isIgnoredForPrettier(file: string, prettierConfig: FrolintConfig["prett
 
 export function applyPrettier(rootDir: string, files: string[], prettierConfig: FrolintConfig["prettier"]) {
   return files
-    .filter(file => isPrettierSupported(file))
-    .filter(file => !isIgnoredForPrettier(file, prettierConfig))
-    .map(file => {
+    .filter((file) => isPrettierSupported(file))
+    .filter((file) => !isIgnoredForPrettier(file, prettierConfig))
+    .map((file) => {
       const filePath = resolve(rootDir, file);
       const options = prettierConfig.config
         ? { config: resolve(rootDir, prettierConfig.config) }


### PR DESCRIPTION
## WHY & WHAT

Support `--bail` option. Behavior is below.

```console
> yarn frolint
yarn run v1.22.4
$ /Users/wantedly215/dev/src/github.com/wantedly/frolint/node_modules/.bin/frolint
Detected 1 error, 0 warnings
./packages/frolint/src/Context.ts: 1 error, 0 warnings found.
  ./packages/frolint/src/Context.ts:22:7 'a' is assigned a value but never used. Allowed unused vars must match /^_/u. (@typescript-eslint/no-unused-vars)
✨  Done in 4.39s.

> yarn frolint --bail 
yarn run v1.22.4
$ /Users/wantedly215/dev/src/github.com/wantedly/frolint/node_modules/.bin/frolint --bail
Detected 1 error, 0 warnings
./packages/frolint/src/Context.ts: 1 error, 0 warnings found.
  ./packages/frolint/src/Context.ts:22:7 'a' is assigned a value but never used. Allowed unused vars must match /^_/u. (@typescript-eslint/no-unused-vars)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```