### PR TITLE
Fix space before function paren option

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -775,7 +775,7 @@ Object {
   "space-before-function-paren": Array [
     "warn",
     Object {
-      "anonymous": "never",
+      "anonymous": "always",
       "asyncArrow": "always",
       "named": "never",
     },

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
@@ -650,7 +650,7 @@ Object {
   "space-before-function-paren": Array [
     "warn",
     Object {
-      "anonymous": "never",
+      "anonymous": "always",
       "asyncArrow": "always",
       "named": "never",
     },

--- a/packages/eslint-config-wantedly-typescript/without-react.js
+++ b/packages/eslint-config-wantedly-typescript/without-react.js
@@ -110,7 +110,7 @@ module.exports = {
     "prefer-template": "warn",
     "quote-props": ["warn", "as-needed"],
     "require-yield": "error",
-    "space-before-function-paren": ["warn", { anonymous: "never", asyncArrow: "always", named: "never" }],
+    "space-before-function-paren": ["warn", { anonymous: "always", asyncArrow: "always", named: "never" }],
     "use-isnan": "error",
     "valid-typeof": "error",
     camelcase: "off",

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -663,7 +663,7 @@ Object {
   "space-before-function-paren": Array [
     "warn",
     Object {
-      "anonymous": "never",
+      "anonymous": "always",
       "asyncArrow": "always",
       "named": "never",
     },

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
@@ -538,7 +538,7 @@ Object {
   "space-before-function-paren": Array [
     "warn",
     Object {
-      "anonymous": "never",
+      "anonymous": "always",
       "asyncArrow": "always",
       "named": "never",
     },

--- a/packages/eslint-config-wantedly/without-react.js
+++ b/packages/eslint-config-wantedly/without-react.js
@@ -117,7 +117,7 @@ module.exports = {
     "prefer-template": "warn",
     "quote-props": ["warn", "as-needed"],
     "require-yield": "error",
-    "space-before-function-paren": ["warn", { anonymous: "never", asyncArrow: "always", named: "never" }],
+    "space-before-function-paren": ["warn", { anonymous: "always", asyncArrow: "always", named: "never" }],
     "use-isnan": "error",
     "valid-typeof": "error",
     camelcase: ["error", { ignoreDestructuring: false, properties: "never" }],


### PR DESCRIPTION
## WHY & WHAT

Conflicting the format in ESLint `space-before-function-paren` rule and Prettier. We should add a space before the parentheses if the function is anonymous function.

```js
// correct
const foo = function () {};

// incorrect
const bar = function() {};
```