### PR TITLE
Add `--expect-no-diff` option

### DIFF
--- a/packages/frolint/src/commands/DefaultCommand.ts
+++ b/packages/frolint/src/commands/DefaultCommand.ts
@@ -10,6 +10,7 @@ import {
   getGitRootDir,
   getStagedFiles,
   getUnstagedFiles,
+  hasChangedFiles,
   isGitExist,
   isInsideGitRepository,
   stageFiles,
@@ -50,6 +51,9 @@ export class DefaultCommand extends Command<FrolintContext> {
 
   @Command.String("-b,--branch")
   private branch?: string;
+
+  @Command.Boolean("--expect-no-diff")
+  private expectNoDiff = false;
 
   @Command.String("-f,--formatter")
   private formatter?: string;
@@ -161,7 +165,15 @@ export class DefaultCommand extends Command<FrolintContext> {
 
     if (this.bail) {
       const errors = reported.reduce((acc, { errorCount }) => acc + errorCount, 0);
-      return errors > 0 ? 1 : 0;
+      if (errors > 0) {
+        return 1;
+      }
+    }
+
+    if (this.expectNoDiff && hasChangedFiles(this.context.cwd)) {
+      console.log(chalk.red(`You specified \`--expect-no-diff\` option but you have some changed files.`));
+
+      return 1;
     }
 
     return 0;

--- a/packages/frolint/src/commands/DefaultCommand.ts
+++ b/packages/frolint/src/commands/DefaultCommand.ts
@@ -27,8 +27,9 @@ export class DefaultCommand extends Command<FrolintContext> {
       ${chalk.bold("Options:")}
 
       --typescript: Use @typescript-eslint/parser as ESLint parser
-      --bail: Fail out on the error instead of tolerating it
       -b,--branch <branch name>: Find the changed files from the specified branch
+      --expect-no-diff: Fail when the changed files exist
+      --expect-no-errors: Fail out on the error instead of tolerating it (previously --bail option)
       -f,--formatter <format>: Print the report with specified format
       --no-stage: Do not stage the files which have the changes made by ESLint and Prettier auto fix functionality
     `,
@@ -46,14 +47,14 @@ export class DefaultCommand extends Command<FrolintContext> {
   @Command.Boolean("--typescript")
   private typescript = true;
 
-  @Command.Boolean("--bail")
-  private bail = false;
-
   @Command.String("-b,--branch")
   private branch?: string;
 
   @Command.Boolean("--expect-no-diff")
   private expectNoDiff = false;
+
+  @Command.Boolean("--expect-no-errors,--bail")
+  private expectNoErrors = false;
 
   @Command.String("-f,--formatter")
   private formatter?: string;
@@ -163,7 +164,7 @@ export class DefaultCommand extends Command<FrolintContext> {
       }
     }
 
-    if (this.bail) {
+    if (this.expectNoErrors) {
       const errors = reported.reduce((acc, { errorCount }) => acc + errorCount, 0);
       if (errors > 0) {
         return 1;

--- a/packages/frolint/src/utils/git.ts
+++ b/packages/frolint/src/utils/git.ts
@@ -93,3 +93,19 @@ export function stageFiles(files: string[], rootDir: string) {
     execSync(`git add ${files.join(" ")}`, { cwd: rootDir });
   }
 }
+
+export function getChangedFiles(rootDir: string) {
+  if (!isGitExist()) {
+    return [];
+  }
+
+  return execSync("git diff-index --name-only HEAD", { cwd: rootDir }).toString().trim().split("\n");
+}
+
+export function hasChangedFiles(rootDir: string) {
+  if (!isGitExist()) {
+    return false;
+  }
+
+  return getChangedFiles(rootDir).length > 0;
+}


### PR DESCRIPTION
## WHY & WHAT

Add `--expect-no-diff` option to fail if the user has changed files and not committed in git.