### PR TITLE
Check the filename has length in `--expect-no-diff` option

### DIFF
--- a/packages/frolint/src/utils/git.ts
+++ b/packages/frolint/src/utils/git.ts
@@ -99,7 +99,11 @@ export function getChangedFiles(rootDir: string) {
     return [];
   }
 
-  return execSync("git diff-index --name-only HEAD", { cwd: rootDir }).toString().trim().split("\n");
+  return execSync("git diff-index --name-only HEAD", { cwd: rootDir })
+    .toString()
+    .trim()
+    .split("\n")
+    .filter((filename) => filename.length > 0);
 }
 
 export function hasChangedFiles(rootDir: string) {


### PR DESCRIPTION
## WHY & WHAT

Check the `git diff-index --name-only HEAD` returns empty string but `split('\n')` returns the array with empty string.

```js
child_process.execSync("git diff-index --name-only HEAD")
  .toString()
  .trim()
  .split("\n");
// => [ '' ]
// We should consider the filename's length
```