### PR TITLE
Wrap with quotes

### DIFF
--- a/packages/frolint/src/utils/git.ts
+++ b/packages/frolint/src/utils/git.ts
@@ -79,7 +79,9 @@ export function getAllFiles(isTypeScript: boolean, rootDir: string) {
     return [];
   }
 
-  const extensions = (isTypeScript ? ["*.js", "*.jsx", "*.ts", "*.tsx"] : ["*.js", "*.jsx"]).join(" ");
+  const extensions = (isTypeScript ? ["*.js", "*.jsx", "*.ts", "*.tsx"] : ["*.js", "*.jsx"])
+    .map((ext) => `'${ext}'`)
+    .join(" ");
 
   return execSync(`git ls-files ${extensions}`, { cwd: rootDir }).toString().trim().split("\n");
 }


### PR DESCRIPTION
## Why & What

In some shell, the wildcard `*` isn't treated properly. So we should wrap with quote.