### PR TITLE
Drop 13 add 14

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Why

Now the Node.js LTS version is below. 13.x is EOL.

Release | Status 
-- | -- 
v10 | Maintenance LTS 
v12 | Active LTS 
v14 | Current

## What

Run CI on 10, 12, 14.