### PR TITLE
feat(eslint-plugin-wantedly): Add new rule 'no-data-testid'

### DIFF
--- a/packages/eslint-plugin-wantedly/docs/rules/no-data-testid.md
+++ b/packages/eslint-plugin-wantedly/docs/rules/no-data-testid.md
@@ -19,7 +19,7 @@ const Component = () => {
 ```jsx
 const Component = () => {
   return (
-    <div data-testid="foo">
+    <div data-testid="foo">     // <- data-testid must not be set as a prop
       Content
     </div>
   );

--- a/packages/eslint-plugin-wantedly/docs/rules/no-data-testid.md
+++ b/packages/eslint-plugin-wantedly/docs/rules/no-data-testid.md
@@ -1,0 +1,45 @@
+# Check if disallowed prop does not appeared in jsx
+
+## Rule Details
+
+#### Valid
+
+```jsx
+const Component = () => {
+  return (
+    <div>
+      Content
+    </div>
+  );
+}
+```
+
+#### Invalid
+
+```jsx
+const Component = () => {
+  return (
+    <div data-testid="foo">
+      Content
+    </div>
+  );
+}
+```
+
+## Options
+
+#### `denyKeyList`
+
+The list of name which is not allowed to assign as prop. Default is `["data-testid"]`.
+
+```json
+{
+  "rule": {
+    "wantedly/no-data-testid": ["error": { "denyKeyList": ["data-testid", "data-test-id"] }]
+  }
+}
+```
+
+```js
+/* eslint wantedly/no-data-testid: ["error", { "denyKeyList": ["data-testid"] }] */
+```

--- a/packages/eslint-plugin-wantedly/package.json
+++ b/packages/eslint-plugin-wantedly/package.json
@@ -27,6 +27,7 @@
     "snake-case": "^3.0.3"
   },
   "devDependencies": {
+    "@types/estree-jsx": "^0.0.0",
     "eslint": "^7.6.0",
     "graphql": "^15.3.0"
   },

--- a/packages/eslint-plugin-wantedly/package.json
+++ b/packages/eslint-plugin-wantedly/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "camel-case": "^4.1.1",
+    "jsx-ast-utils": "^2.4.1",
     "pascal-case": "^3.1.1",
     "snake-case": "^3.0.3"
   },

--- a/packages/eslint-plugin-wantedly/package.json
+++ b/packages/eslint-plugin-wantedly/package.json
@@ -26,7 +26,6 @@
     "snake-case": "^3.0.3"
   },
   "devDependencies": {
-    "@types/estree-jsx": "^0.0.0",
     "@typescript-eslint/experimental-utils": "^3.9.0",
     "eslint": "^7.7.0",
     "graphql": "^15.3.0"

--- a/packages/eslint-plugin-wantedly/package.json
+++ b/packages/eslint-plugin-wantedly/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "camel-case": "^4.1.1",
-    "jsx-ast-utils": "^2.4.1",
     "pascal-case": "^3.1.1",
     "snake-case": "^3.0.3"
   },

--- a/packages/eslint-plugin-wantedly/package.json
+++ b/packages/eslint-plugin-wantedly/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@types/estree-jsx": "^0.0.0",
+    "@typescript-eslint/experimental-utils": "^3.9.0",
     "eslint": "^7.6.0",
     "graphql": "^15.3.0"
   },

--- a/packages/eslint-plugin-wantedly/src/@types/jsx-ast-utils.d.ts
+++ b/packages/eslint-plugin-wantedly/src/@types/jsx-ast-utils.d.ts
@@ -1,4 +1,5 @@
+import { JSXAttribute, JSXSpreadAttribute } from "estree-jsx";
+
 declare module "jsx-ast-utils" {
-  export function getPropValue(name: string): any;
-  export function getProp(element: any, name: string): any;
+  export function hasProp(element: Array<JSXAttribute | JSXSpreadAttribute>, name: string): boolean;
 }

--- a/packages/eslint-plugin-wantedly/src/@types/jsx-ast-utils.d.ts
+++ b/packages/eslint-plugin-wantedly/src/@types/jsx-ast-utils.d.ts
@@ -1,0 +1,4 @@
+declare module "jsx-ast-utils" {
+  export function getPropValue(name: string): any;
+  export function getProp(element: any, name: string): any;
+}

--- a/packages/eslint-plugin-wantedly/src/@types/jsx-ast-utils.d.ts
+++ b/packages/eslint-plugin-wantedly/src/@types/jsx-ast-utils.d.ts
@@ -1,5 +1,0 @@
-import { TSESTree } from "@typescript-eslint/experimental-utils";
-
-declare module "jsx-ast-utils" {
-  export function hasProp(element: TSESTree.JSXAttribute[], name: string): boolean;
-}

--- a/packages/eslint-plugin-wantedly/src/@types/jsx-ast-utils.d.ts
+++ b/packages/eslint-plugin-wantedly/src/@types/jsx-ast-utils.d.ts
@@ -1,5 +1,5 @@
-import { JSXAttribute, JSXSpreadAttribute } from "estree-jsx";
+import { TSESTree } from "@typescript-eslint/experimental-utils";
 
 declare module "jsx-ast-utils" {
-  export function hasProp(element: Array<JSXAttribute | JSXSpreadAttribute>, name: string): boolean;
+  export function hasProp(element: TSESTree.JSXAttribute[], name: string): boolean;
 }

--- a/packages/eslint-plugin-wantedly/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/eslint-plugin-wantedly/src/__tests__/__snapshots__/index.test.ts.snap
@@ -82,6 +82,16 @@ Object {
         "type": "suggestion",
       },
     },
+    "no-data-testid": Object {
+      "create": [Function],
+      "meta": Object {
+        "docs": Object {
+          "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/no-data-testid.md",
+        },
+        "fixable": "code",
+        "type": "suggestion",
+      },
+    },
   },
 }
 `;

--- a/packages/eslint-plugin-wantedly/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/eslint-plugin-wantedly/src/__tests__/__snapshots__/index.test.ts.snap
@@ -86,9 +86,28 @@ Object {
       "create": [Function],
       "meta": Object {
         "docs": Object {
+          "category": "Stylistic Issues",
+          "description": "Disallow specific keys as jsx props",
+          "recommended": "error",
           "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/no-data-testid.md",
         },
         "fixable": "code",
+        "messages": Object {
+          "noDataTestId": "Attribute {{key}} is not allowed.",
+        },
+        "schema": Array [
+          Object {
+            "properties": Object {
+              "denyKeyList": Object {
+                "default": Array [
+                  "data-testid",
+                ],
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+        ],
         "type": "suggestion",
       },
     },

--- a/packages/eslint-plugin-wantedly/src/index.ts
+++ b/packages/eslint-plugin-wantedly/src/index.ts
@@ -6,6 +6,7 @@ import * as NEXUS_FIELD_DESCRIPTION from "./rules/nexus-field-description";
 import * as NEXUS_PASCAL_CASE_TYPE_NAME from "./rules/nexus-pascal-case-type-name";
 import * as NEXUS_TYPE_DESCRIPTION from "./rules/nexus-type-description";
 import * as NEXUS_UPPER_CASE_ENUM_MEMBERS from "./rules/nexus-upper-case-enum-members";
+import * as NO_DATA_TESTID from "./rules/no-data-testid";
 
 export const rules = {
   [GRAPHQL_OPERATION_NAME.RULE_NAME]: GRAPHQL_OPERATION_NAME.RULE,
@@ -16,4 +17,5 @@ export const rules = {
   [NEXUS_PASCAL_CASE_TYPE_NAME.RULE_NAME]: NEXUS_PASCAL_CASE_TYPE_NAME.RULE,
   [NEXUS_TYPE_DESCRIPTION.RULE_NAME]: NEXUS_TYPE_DESCRIPTION.RULE,
   [NEXUS_UPPER_CASE_ENUM_MEMBERS.RULE_NAME]: NEXUS_UPPER_CASE_ENUM_MEMBERS.RULE,
+  [NO_DATA_TESTID.RULE_NAME]: NO_DATA_TESTID.RULE,
 };

--- a/packages/eslint-plugin-wantedly/src/rules/__tests__/no-data-testid.test.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/__tests__/no-data-testid.test.ts
@@ -1,10 +1,11 @@
-import { RuleTester } from "eslint";
+import { TSESLint } from "@typescript-eslint/experimental-utils";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import ESLintConfigWantedly from "eslint-config-wantedly/without-react";
 import { RULE, RULE_NAME } from "../no-data-testid";
 
-new RuleTester({
+// new RuleTester({
+new TSESLint.RuleTester({
   parser: require.resolve(ESLintConfigWantedly.parser),
   parserOptions: ESLintConfigWantedly.parserOptions,
 }).run(RULE_NAME, RULE, {
@@ -16,16 +17,43 @@ new RuleTester({
   invalid: [
     {
       code: `<div data-testid="foo" />`,
-      errors: ["Attribute data-testid is not allowed."],
+      errors: [
+        {
+          messageId: "noDataTestId",
+          data: {
+            key: "data-testid"
+          }
+        }
+      ],
     },
     {
       code: `<div data-test-id="foo" />`,
-      errors: ["Attribute data-test-id is not allowed."],
+      errors: [
+        {
+          messageId: "noDataTestId",
+          data: {
+            key: "data-test-id"
+          }
+        }
+      ],
       options: [{ denyKeyList: ["data-test-id"] }],
     },
     {
       code: `<div data-testid1="foo" data-testid2="bar" />`,
-      errors: ["Attribute data-testid1 is not allowed.", "Attribute data-testid2 is not allowed."],
+      errors: [
+        {
+          messageId: "noDataTestId",
+          data: {
+            key: "data-testid1"
+          }
+        },
+        {
+          messageId: "noDataTestId",
+          data: {
+            key: "data-testid2"
+          }
+        }
+      ],
       options: [{ denyKeyList: ["data-testid1", "data-testid2"] }],
     },
     {
@@ -37,7 +65,20 @@ new RuleTester({
           </div>
         </div>
       `,
-      errors: ["Attribute data-testid is not allowed.", "Attribute data-testid is not allowed."],
+      errors: [
+        {
+          messageId: "noDataTestId",
+          data: {
+            key: "data-testid"
+          }
+        },
+        {
+          messageId: "noDataTestId",
+          data: {
+            key: "data-testid"
+          }
+        }
+      ],
     },
   ],
 });

--- a/packages/eslint-plugin-wantedly/src/rules/__tests__/no-data-testid.test.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/__tests__/no-data-testid.test.ts
@@ -28,5 +28,16 @@ new RuleTester({
       errors: ["Attribute data-testid1 is not allowed.", "Attribute data-testid2 is not allowed."],
       options: [{ denyKeyList: ["data-testid1", "data-testid2"] }],
     },
+    {
+      code: `
+        <div>
+          <div data-testid="foo">
+          </div>
+          <div data-testid="bar">
+          </div>
+        </div>
+      `,
+      errors: ["Attribute data-testid is not allowed.", "Attribute data-testid is not allowed."],
+    },
   ],
 });

--- a/packages/eslint-plugin-wantedly/src/rules/__tests__/no-data-testid.test.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/__tests__/no-data-testid.test.ts
@@ -1,0 +1,32 @@
+import { RuleTester } from "eslint";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import ESLintConfigWantedly from "eslint-config-wantedly/without-react";
+import { RULE, RULE_NAME } from "../no-data-testid";
+
+new RuleTester({
+  parser: require.resolve(ESLintConfigWantedly.parser),
+  parserOptions: ESLintConfigWantedly.parserOptions,
+}).run(RULE_NAME, RULE, {
+  valid: [
+    {
+      code: `<div />`,
+    },
+  ],
+  invalid: [
+    {
+      code: `<div data-testid="foo" />`,
+      errors: ["Attribute data-testid is not allowed."],
+    },
+    {
+      code: `<div data-test-id="foo" />`,
+      errors: ["Attribute data-test-id is not allowed."],
+      options: [{ denyKeyList: ["data-test-id"] }],
+    },
+    {
+      code: `<div data-testid1="foo" data-testid2="bar" />`,
+      errors: ["Attribute data-testid1 is not allowed.", "Attribute data-testid2 is not allowed."],
+      options: [{ denyKeyList: ["data-testid1", "data-testid2"] }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-wantedly/src/rules/no-data-testid.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/no-data-testid.ts
@@ -1,5 +1,4 @@
 import { TSESLint } from "@typescript-eslint/experimental-utils";
-import { hasProp } from "jsx-ast-utils";
 import { docsUrl, getOptionWithDefault } from "./utils";
 
 const linter = new TSESLint.Linter();
@@ -37,19 +36,18 @@ linter.defineRule(RULE_NAME, {
   create(context) {
     const option = getOptionWithDefault(context, DEFAULT_OPTION);
     return {
-      JSXOpeningElement: (node) => {
+      JSXAttribute: (node) => {
         option.denyKeyList.forEach((key: string) => {
-          if (hasProp(node.attributes, key)) {
+          if (key === node.name.name) {
             context.report({
-              loc: node.loc!,
+              loc: node.loc,
               messageId: "noDataTestId",
               data: {
-                key,
-              },
-            });
+                key
+              }
+            })
           }
-        });
-        return;
+        })
       },
     };
   },

--- a/packages/eslint-plugin-wantedly/src/rules/no-data-testid.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/no-data-testid.ts
@@ -1,0 +1,42 @@
+import { Linter, Rule } from "eslint";
+import { getProp } from "jsx-ast-utils";
+import { docsUrl, getOptionWithDefault } from "./utils";
+
+const linter = new Linter();
+export const RULE_NAME = "no-data-testid";
+
+const DEFAULT_OPTION = {
+  denyKeyList: ["data-testid"],
+};
+
+linter.defineRule(RULE_NAME, {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    docs: {
+      url: docsUrl(RULE_NAME),
+    },
+  },
+  create(context) {
+    const option = getOptionWithDefault(context, DEFAULT_OPTION);
+    return {
+      JSXOpeningElement: (node: any) => {
+        option.denyKeyList.forEach((key: string) => {
+          const props = getProp(node.attributes, key);
+          if (props) {
+            context.report({
+              node,
+              message: "Attribute {{key}} is not allowed.",
+              data: {
+                key,
+              },
+            });
+          }
+        });
+        return;
+      },
+    };
+  },
+});
+
+export const RULE = linter.getRules().get(RULE_NAME) as Rule.RuleModule;

--- a/packages/eslint-plugin-wantedly/src/rules/no-data-testid.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/no-data-testid.ts
@@ -1,9 +1,8 @@
-import { Linter, Rule } from "eslint";
-import { JSXOpeningElement } from "estree-jsx";
+import { TSESLint } from "@typescript-eslint/experimental-utils";
 import { hasProp } from "jsx-ast-utils";
 import { docsUrl, getOptionWithDefault } from "./utils";
 
-const linter = new Linter();
+const linter = new TSESLint.Linter();
 export const RULE_NAME = "no-data-testid";
 
 const DEFAULT_OPTION = {
@@ -15,21 +14,35 @@ linter.defineRule(RULE_NAME, {
     type: "suggestion",
     fixable: "code",
     docs: {
+      category: "Stylistic Issues",
+      description: "Disallow specific keys as jsx props",
+      recommended: "error",
       url: docsUrl(RULE_NAME),
     },
+    messages: {
+      noDataTestId: "Attribute {{key}} is not allowed.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          denyKeyList: {
+            type: "array",
+            default: ["data-testid"],
+          }
+        }
+      }
+    ],
   },
-  // NOTE: { [key: string]: (node: JSXOpeningElement) => void } does not meet RuleModule.create type definition
-  // cf. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a0b66498155af79ddc7cdb52dba529eb5b04eae8/types/eslint/index.d.ts#L241-L266
-  /* @ts-ignore */
   create(context) {
     const option = getOptionWithDefault(context, DEFAULT_OPTION);
     return {
-      JSXOpeningElement: (node: JSXOpeningElement) => {
+      JSXOpeningElement: (node) => {
         option.denyKeyList.forEach((key: string) => {
           if (hasProp(node.attributes, key)) {
             context.report({
               loc: node.loc!,
-              message: "Attribute {{key}} is not allowed.",
+              messageId: "noDataTestId",
               data: {
                 key,
               },
@@ -42,4 +55,4 @@ linter.defineRule(RULE_NAME, {
   },
 });
 
-export const RULE = linter.getRules().get(RULE_NAME) as Rule.RuleModule;
+export const RULE = linter.getRules().get(RULE_NAME) as TSESLint.RuleModule<string, unknown[], TSESLint.RuleListener>;

--- a/packages/eslint-plugin-wantedly/src/rules/no-data-testid.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/no-data-testid.ts
@@ -1,5 +1,6 @@
 import { Linter, Rule } from "eslint";
-import { getProp } from "jsx-ast-utils";
+import { JSXOpeningElement } from "estree-jsx";
+import { hasProp } from "jsx-ast-utils";
 import { docsUrl, getOptionWithDefault } from "./utils";
 
 const linter = new Linter();
@@ -17,15 +18,15 @@ linter.defineRule(RULE_NAME, {
       url: docsUrl(RULE_NAME),
     },
   },
+  /* @ts-ignore */
   create(context) {
     const option = getOptionWithDefault(context, DEFAULT_OPTION);
     return {
-      JSXOpeningElement: (node: any) => {
+      JSXOpeningElement: (node: JSXOpeningElement) => {
         option.denyKeyList.forEach((key: string) => {
-          const props = getProp(node.attributes, key);
-          if (props) {
+          if (hasProp(node.attributes, key)) {
             context.report({
-              node,
+              loc: node.loc!,
               message: "Attribute {{key}} is not allowed.",
               data: {
                 key,

--- a/packages/eslint-plugin-wantedly/src/rules/no-data-testid.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/no-data-testid.ts
@@ -18,6 +18,8 @@ linter.defineRule(RULE_NAME, {
       url: docsUrl(RULE_NAME),
     },
   },
+  // NOTE: { [key: string]: (node: JSXOpeningElement) => void } does not meet RuleModule.create type definition
+  // cf. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a0b66498155af79ddc7cdb52dba529eb5b04eae8/types/eslint/index.d.ts#L241-L266
   /* @ts-ignore */
   create(context) {
     const option = getOptionWithDefault(context, DEFAULT_OPTION);

--- a/packages/eslint-plugin-wantedly/tsconfig.json
+++ b/packages/eslint-plugin-wantedly/tsconfig.json
@@ -3,9 +3,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "baseUrl": ".",
-    "paths": {
-      "jsx-ast-utils": ["./src/@types/jsx-ast-utils.d.ts"]
-    }
+    "baseUrl": "."
   }
 }

--- a/packages/eslint-plugin-wantedly/tsconfig.json
+++ b/packages/eslint-plugin-wantedly/tsconfig.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "baseUrl": "./src/@types",
+    "baseUrl": ".",
     "paths": {
-      "jsx-ast-utils": ["jsx-ast-utils.d.ts"]
+      "jsx-ast-utils": ["./src/@types/jsx-ast-utils.d.ts"]
     }
   }
 }

--- a/packages/eslint-plugin-wantedly/tsconfig.json
+++ b/packages/eslint-plugin-wantedly/tsconfig.json
@@ -2,6 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "baseUrl": "./src/@types",
+    "paths": {
+      "jsx-ast-utils": ["jsx-ast-utils.d.ts"]
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1838,6 +1838,17 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
+"@typescript-eslint/experimental-utils@^3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.9.0.tgz#3171d8ddba0bf02a8c2034188593630914fcf5ee"
+  integrity sha512-/vSHUDYizSOhrOJdjYxPNGfb4a3ibO8zd4nUKo/QBFOmxosT3cVUV7KIg8Dwi6TXlr667G7YPqFK9+VSZOorNA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/types" "3.9.0"
+    "@typescript-eslint/typescript-estree" "3.9.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
 "@typescript-eslint/parser@^3.8.0":
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.8.0.tgz#8e1dcd404299bf79492409c81c415fa95a7c622b"
@@ -1853,6 +1864,11 @@
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.8.0.tgz#58581dd863f86e0cd23353d94362bb90b4bea796"
   integrity sha512-8kROmEQkv6ss9kdQ44vCN1dTrgu4Qxrd2kXr10kz2NP5T8/7JnEfYNxCpPkArbLIhhkGLZV3aVMplH1RXQRF7Q==
+
+"@typescript-eslint/types@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.9.0.tgz#be9d0aa451e1bf3ce99f2e6920659e5b2e6bfe18"
+  integrity sha512-rb6LDr+dk9RVVXO/NJE8dT1pGlso3voNdEIN8ugm4CWM5w5GimbThCMiMl4da1t5u3YwPWEwOnKAULCZgBtBHg==
 
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
@@ -1881,10 +1897,31 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.9.0.tgz#c6abbb50fa0d715cab46fef67ca6378bf2eaca13"
+  integrity sha512-N+158NKgN4rOmWVfvKOMoMFV5n8XxAliaKkArm/sOypzQ0bUL8MSnOEBW3VFIeffb/K5ce/cAV0yYhR7U4ALAA==
+  dependencies:
+    "@typescript-eslint/types" "3.9.0"
+    "@typescript-eslint/visitor-keys" "3.9.0"
+    debug "^4.1.1"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/visitor-keys@3.8.0":
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.8.0.tgz#ad35110249fb3fc30a36bfcbfeea93e710cfaab1"
   integrity sha512-gfqQWyVPpT9NpLREXNR820AYwgz+Kr1GuF3nf1wxpHD6hdxI62tq03ToomFnDxY0m3pUB39IF7sil7D5TQexLA==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/visitor-keys@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.9.0.tgz#44de8e1b1df67adaf3b94d6b60b80f8faebc8dd3"
+  integrity sha512-O1qeoGqDbu0EZUC/MZ6F1WHTIzcBVhGqDj3LhTnj65WUA548RXVxUHbYhAW9bZWfb2rnX9QsbbP5nmeJ5Z4+ng==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1667,6 +1667,13 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
+"@types/estree-jsx@^0.0.0":
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/@types/estree-jsx/-/estree-jsx-0.0.0.tgz#41447d0019a12dd43986cd23ca1b10f9a350a178"
+  integrity sha512-qbF1vq7M/ACuNkA3fbLJY0o+O+Yy4TPICtu6bUfX1IBdSOxBDms9zAdbhSfYuHTmWLakWg5zOJ64JrJae1ksdg==
+  dependencies:
+    "@types/estree" "*"
+
 "@types/estree@*", "@types/estree@^0.0.45":
   version "0.0.45"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1667,13 +1667,6 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree-jsx@^0.0.0":
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/@types/estree-jsx/-/estree-jsx-0.0.0.tgz#41447d0019a12dd43986cd23ca1b10f9a350a178"
-  integrity sha512-qbF1vq7M/ACuNkA3fbLJY0o+O+Yy4TPICtu6bUfX1IBdSOxBDms9zAdbhSfYuHTmWLakWg5zOJ64JrJae1ksdg==
-  dependencies:
-    "@types/estree" "*"
-
 "@types/estree@*", "@types/estree@^0.0.45":
   version "0.0.45"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"


### PR DESCRIPTION
## Why

`data-testid` is useful to test components.
However, if it remains on our production code, it is going to be easier for those who use RPA or some kind of automation tools to crawl/scrape the page.
So we use [@welldone-software/babel-plugin-react-add-test-id](https://www.npmjs.com/package/@welldone-software/babel-plugin-react-add-test-id) to add 'data-testid' to each component on test environment only.
But still there are possibilities that the attribute sneak in our code.
Maybe we can reject those codes by reviewing but it is hard to do that with a 100% possibility.
So I want to introduce this rule to reject `data-testid`

## What

Add new rule `no-data-testid`.

valid
```
<div />
```

invalid
```
<div data-testid="foo" />
```