### PR TITLE
Use consistent type imports rule in this project

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,11 @@
   },
   "rules": {
     "no-console": "off",
-    "@typescript-eslint/no-var-requires": "off"
+    "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      { "prefer": "type-imports", "disallowTypeAnnotations": true }
+    ]
   },
   "parserOptions": {
     "project": "./tsconfig.json"

--- a/packages/eslint-plugin-wantedly/src/rules/graphql-operation-name.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/graphql-operation-name.ts
@@ -1,4 +1,6 @@
-import { Linter, Rule } from "eslint";
+import type { Rule } from "eslint";
+import { Linter } from "eslint";
+import type * as GraphQL from "graphql";
 import { pascalCase } from "pascal-case";
 import { docsUrl, getOptionWithDefault } from "./utils";
 
@@ -34,7 +36,7 @@ linter.defineRule(RULE_NAME, {
 
     const option = getOptionWithDefault(context, DEFAULT_OPTION);
     const autofixEnabled = option.autofix;
-    const graphql = require("graphql") as typeof import("graphql");
+    const graphql = require("graphql") as typeof GraphQL;
 
     return {
       TaggedTemplateExpression(node) {

--- a/packages/eslint-plugin-wantedly/src/rules/graphql-pascal-case-type-name.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/graphql-pascal-case-type-name.ts
@@ -1,5 +1,7 @@
-import { Linter, Rule } from "eslint";
+import type { Rule } from "eslint";
+import { Linter } from "eslint";
 import type { TaggedTemplateExpression } from "estree";
+import type * as GraphQL from "graphql";
 import type {
   ASTNode,
   FragmentDefinitionNode,
@@ -87,7 +89,7 @@ linter.defineRule(RULE_NAME, {
 
     const option = getOptionWithDefault(context, DEFAULT_OPTION);
     const autofixEnabled = option.autofix;
-    const graphql = require("graphql") as typeof import("graphql");
+    const graphql = require("graphql") as typeof GraphQL;
 
     return {
       TaggedTemplateExpression(node) {

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-camel-case-field-name.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-camel-case-field-name.ts
@@ -1,5 +1,6 @@
 import { camelCase } from "camel-case";
-import { Linter, Rule } from "eslint";
+import type { Rule } from "eslint";
+import { Linter } from "eslint";
 import type { Property } from "estree";
 import { docsUrl, getOptionWithDefault, isNexusSchemaImported } from "./utils";
 

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-enum-values-description.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-enum-values-description.ts
@@ -1,4 +1,5 @@
-import { AST, Linter, Rule } from "eslint";
+import type { AST, Rule } from "eslint";
+import { Linter } from "eslint";
 import type { ObjectExpression, Property, VariableDeclarator } from "estree";
 import { docsUrl, isNexusSchemaImported } from "./utils";
 

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-field-description.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-field-description.ts
@@ -1,5 +1,6 @@
-import { Linter, Rule } from "eslint";
-import { Property } from "estree";
+import type { Rule } from "eslint";
+import { Linter } from "eslint";
+import type { Property } from "estree";
 import { docsUrl, isNexusSchemaImported } from "./utils";
 
 const linter = new Linter();

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-pascal-case-type-name.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-pascal-case-type-name.ts
@@ -1,5 +1,6 @@
-import { Linter, Rule } from "eslint";
-import { Property } from "estree";
+import type { Rule } from "eslint";
+import { Linter } from "eslint";
+import type { Property } from "estree";
 import { pascalCase } from "pascal-case";
 import { snakeCase } from "snake-case";
 import { docsUrl, getOptionWithDefault, isNexusSchemaImported } from "./utils";

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-type-description.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-type-description.ts
@@ -1,5 +1,6 @@
-import { Linter, Rule } from "eslint";
-import { Property } from "estree";
+import type { Rule } from "eslint";
+import { Linter } from "eslint";
+import type { Property } from "estree";
 import { snakeCase } from "snake-case";
 import { docsUrl, isNexusSchemaImported } from "./utils";
 

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-upper-case-enum-members.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-upper-case-enum-members.ts
@@ -1,5 +1,6 @@
-import { AST, Linter, Rule } from "eslint";
-import { Node, ObjectExpression, Property } from "estree";
+import type { AST, Rule } from "eslint";
+import { Linter } from "eslint";
+import type { Node, ObjectExpression, Property } from "estree";
 import { snakeCase } from "snake-case";
 import { docsUrl, getOptionWithDefault, isNexusSchemaImported } from "./utils";
 

--- a/packages/eslint-plugin-wantedly/src/rules/utils.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/utils.ts
@@ -1,4 +1,4 @@
-import { Node } from "estree";
+import type { Node } from "estree";
 
 export function getOptionWithDefault(context: any, defaultOption: any) {
   return context.options.reduce((acc: any, obj: any) => ({ ...acc, ...obj }), defaultOption);

--- a/packages/frolint/src/Context.ts
+++ b/packages/frolint/src/Context.ts
@@ -1,4 +1,4 @@
-import { BaseContext } from "clipanion";
+import type { BaseContext } from "clipanion";
 
 export type FrolintConfig = {
   typescript: boolean;

--- a/packages/frolint/src/commands/DefaultCommand.ts
+++ b/packages/frolint/src/commands/DefaultCommand.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { Command } from "clipanion";
 import { writeFileSync } from "fs";
 import { relative, resolve } from "path";
-import { FrolintContext } from "../Context";
+import type { FrolintContext } from "../Context";
 import { applyEslint } from "../utils/eslint";
 import {
   getAllFiles,

--- a/packages/frolint/src/commands/ExportCommand.ts
+++ b/packages/frolint/src/commands/ExportCommand.ts
@@ -3,7 +3,7 @@
 import { Command } from "clipanion";
 import { accessSync, constants, writeFileSync } from "fs";
 import { resolve } from "path";
-import { FrolintContext } from "../Context";
+import type { FrolintContext } from "../Context";
 import { getGitRootDir } from "../utils/git";
 
 export class ExportCommand extends Command<FrolintContext> {

--- a/packages/frolint/src/commands/HelpCommand.ts
+++ b/packages/frolint/src/commands/HelpCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from "clipanion";
-import { FrolintContext } from "../Context";
+import type { FrolintContext } from "../Context";
 import { DefaultCommand } from "./DefaultCommand";
 
 export class HelpCommand extends Command<FrolintContext> {

--- a/packages/frolint/src/commands/InstallCommand.ts
+++ b/packages/frolint/src/commands/InstallCommand.ts
@@ -1,6 +1,6 @@
 import { Command } from "clipanion";
 import { accessSync, constants, writeFileSync } from "fs";
-import { FrolintContext } from "../Context";
+import type { FrolintContext } from "../Context";
 import { END_COMMENT, HOOKS_CATEGORY, START_COMMENT } from "../utils/constants";
 import { getPreCommitHookPath, isGitExist, isInsideGitRepository, isPreCommitHookInstalled } from "../utils/git";
 

--- a/packages/frolint/src/commands/PreCommitCommand.ts
+++ b/packages/frolint/src/commands/PreCommitCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from "clipanion";
-import { FrolintContext } from "../Context";
+import type { FrolintContext } from "../Context";
 
 export class PreCommitCommand extends Command<FrolintContext> {
   @Command.Rest()

--- a/packages/frolint/src/commands/PrintConfigCommand.ts
+++ b/packages/frolint/src/commands/PrintConfigCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from "clipanion";
-import { FrolintContext } from "../Context";
+import type { FrolintContext } from "../Context";
 import { getCLI } from "../utils/eslint";
 
 export class PrintConfigCommand extends Command<FrolintContext> {

--- a/packages/frolint/src/commands/UninstallCommand.ts
+++ b/packages/frolint/src/commands/UninstallCommand.ts
@@ -1,6 +1,6 @@
 import { Command } from "clipanion";
 import { accessSync, constants, readFileSync, writeFileSync } from "fs";
-import { FrolintContext } from "../Context";
+import type { FrolintContext } from "../Context";
 import { END_COMMENT, HOOKS_CATEGORY, START_COMMENT } from "../utils/constants";
 import { getPreCommitHookPath, isGitExist, isInsideGitRepository, isPreCommitHookInstalled } from "../utils/git";
 

--- a/packages/frolint/src/commands/VersionCommand.ts
+++ b/packages/frolint/src/commands/VersionCommand.ts
@@ -1,5 +1,5 @@
 import { Command } from "clipanion";
-import { FrolintContext } from "../Context";
+import type { FrolintContext } from "../Context";
 
 export class VersionCommand extends Command<FrolintContext> {
   public static usage = Command.Usage({

--- a/packages/frolint/src/index.ts
+++ b/packages/frolint/src/index.ts
@@ -8,7 +8,7 @@ import { PreCommitCommand } from "./commands/PreCommitCommand";
 import { PrintConfigCommand } from "./commands/PrintConfigCommand";
 import { UninstallCommand } from "./commands/UninstallCommand";
 import { VersionCommand } from "./commands/VersionCommand";
-import { FrolintConfig, FrolintContext } from "./Context";
+import type { FrolintConfig, FrolintContext } from "./Context";
 
 const binaryName = "frolint";
 const binaryVersion = "2.1.3";

--- a/packages/frolint/src/index.ts
+++ b/packages/frolint/src/index.ts
@@ -11,7 +11,7 @@ import { VersionCommand } from "./commands/VersionCommand";
 import type { FrolintConfig, FrolintContext } from "./Context";
 
 const binaryName = "frolint";
-const binaryVersion = "2.1.3";
+const binaryVersion = "2.3.0";
 
 const cli = new Cli<FrolintContext>({
   binaryLabel: "FROntend LINt Tool",

--- a/packages/frolint/src/utils/eslint.ts
+++ b/packages/frolint/src/utils/eslint.ts
@@ -1,7 +1,7 @@
 import { CLIEngine } from "eslint";
 import { resolve } from "path";
 import { sync } from "resolve";
-import { FrolintConfig } from "../Context";
+import type { FrolintConfig } from "../Context";
 
 function detectReactVersion(basedir: string) {
   try {

--- a/packages/frolint/src/utils/prettier.ts
+++ b/packages/frolint/src/utils/prettier.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from "fs";
 import { extname, resolve } from "path";
-import prettier, { BuiltInParserName, ResolveConfigOptions } from "prettier";
+import type { BuiltInParserName, ResolveConfigOptions } from "prettier";
+import prettier from "prettier";
 import prettierConfigWantedly from "prettier-config-wantedly";
-import { FrolintConfig } from "../Context";
+import type { FrolintConfig } from "../Context";
 
 const supportedLanguages = [
   "JavaScript",

--- a/packages/frolint/src/utils/report.ts
+++ b/packages/frolint/src/utils/report.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { CLIEngine } from "eslint";
+import type { CLIEngine } from "eslint";
 import { relative } from "path";
 import { getCLI } from "./eslint";
 


### PR DESCRIPTION
## Why & What

Introduce [`@typescript-eslint/consistent-type-imports`](https://github.com/typescript-eslint/typescript-eslint/blob/9a6c3628a2f3a7748b7a4b9b0c55400c8d7dfeae/packages/eslint-plugin/docs/rules/consistent-type-imports.md) rule for this project.

