### PR TITLE
Introduce debug log

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,21 @@
 
 - [eslint-config-wantedly-typescript](https://github.com/wantedly/frolint/tree/master/packages/eslint-config-wantedly-typescript) [![npm version](https://badge.fury.io/js/eslint-config-wantedly-typescript.svg)](https://badge.fury.io/js/eslint-config-wantedly-typescript)
 - [eslint-config-wantedly](https://github.com/wantedly/frolint/tree/master/packages/eslint-config-wantedly) [![npm version](https://badge.fury.io/js/eslint-config-wantedly.svg)](https://badge.fury.io/js/eslint-config-wantedly)
+- [eslint-plugin-use-macros](https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-use-macros) [![npm version](https://badge.fury.io/js/eslint-plugin-use-macros.svg)](https://badge.fury.io/js/eslint-plugin-use-macros)
+- [eslint-plugin-wantedly](https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly) [![npm version](https://badge.fury.io/js/eslint-plugin-wantedly.svg)](https://badge.fury.io/js/eslint-plugin-wantedly)
 - [frolint](https://github.com/wantedly/frolint/tree/master/packages/frolint) [![npm version](https://badge.fury.io/js/frolint.svg)](https://badge.fury.io/js/frolint)
 - [prettier-config-wantedly](https://github.com/wantedly/frolint/tree/master/packages/prettier-config-wantedly) [![npm version](https://badge.fury.io/js/prettier-config-wantedly.svg)](https://badge.fury.io/js/prettier-config-wantedly)
-- [eslint-plugin-wantedly](https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly) [![npm version](https://badge.fury.io/js/eslint-plugin-wantedly.svg)](https://badge.fury.io/js/eslint-plugin-wantedly)
+
+<details>
+
+```fish
+# Create above list with fish shell script
+for package in (yarn -s lerna ls --loglevel silent)
+    echo "- [$package](https://github.com/wantedly/frolint/tree/master/packages/$package) [![npm version](https://badge.fury.io/js/$package.svg)](https://badge.fury.io/js/$package)"
+end
+```
+
+</details>
 
 ## How to contribute
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint:ci": "frolint --expect-no-errors",
     "changelog": "yarn --silent lerna-changelog | cat - CHANGELOG.md | yarn --silent prettier --stdin-filepath CHANGELOG.md > CHANGELOG_BACKUP.md; mv CHANGELOG_BACKUP.md CHANGELOG.md",
     "build": "lerna run build",
-    "build:watch": "lerna exec npm run build:watch",
+    "build:watch": "lerna run --parallel build:watch",
     "prerelease": "yarn install --force && yarn run build",
     "release": "lerna publish --force-publish --preid beta --pre-dist-tag beta"
   },

--- a/packages/frolint/README.md
+++ b/packages/frolint/README.md
@@ -162,3 +162,19 @@ Now, `frolint` supports Prettier. So `frolint` command format the code automatic
   }
 }
 ```
+
+### Debugging
+
+If you want to watch debug log, you can use `DEBUG=frolint:*` environment variable to output debugging information to the console.
+
+```console
+> DEBUG=frolint:* yarn frolint
+...
+  frolint:DefaultCommand Start stagings files +552ms
+  frolint:DefaultCommand Start reporting results to console +4ms
+  frolint:report Start reporting using frolint format +0ms
+  frolint:report No errors and warnings +0ms
+No errors and warnings!
+  frolint:DefaultCommand Execution finished +1ms
+  frolint:main Linting and Formatting complete +1s
+```

--- a/packages/frolint/package.json
+++ b/packages/frolint/package.json
@@ -9,6 +9,7 @@
     "clipanion": "^2.6.2",
     "command-exists": "^1.2.9",
     "cosmiconfig": "^7.0.0",
+    "debug": "^4.3.1",
     "eslint": "^7.15.0",
     "eslint-config-wantedly": "^2.2.8",
     "eslint-config-wantedly-typescript": "^2.2.8",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@types/command-exists": "^1.2.0",
     "@types/cosmiconfig": "^6.0.0",
+    "@types/debug": "^4.1.5",
     "@types/eslint": "^7.2.6",
     "@types/mock-fs": "^4.13.0",
     "@types/prettier": "^2.1.5",

--- a/packages/frolint/src/Context.ts
+++ b/packages/frolint/src/Context.ts
@@ -1,4 +1,5 @@
 import type { BaseContext } from "clipanion";
+import type { Debugger } from "debug";
 
 export type FrolintConfig = {
   typescript: boolean;
@@ -12,9 +13,10 @@ export type FrolintConfig = {
   };
 };
 
-export type FrolintContext = BaseContext & {
+export interface FrolintContext extends BaseContext {
   cwd: string;
   config: FrolintConfig;
   preCommit: boolean;
   version: string;
-};
+  debug: (namespace: string) => Debugger;
+}

--- a/packages/frolint/src/commands/DefaultCommand.ts
+++ b/packages/frolint/src/commands/DefaultCommand.ts
@@ -136,9 +136,11 @@ export class DefaultCommand extends Command<FrolintContext> {
     report.results.forEach((result) => {
       const { filePath, output } = result;
       if (output) {
+        log("File (%s) has changed. Overwriting..", filePath);
         writeFileSync(filePath, output);
 
         if (!this.noStage && isFullyStaged(filePath)) {
+          log("File (%s) should be staged", filePath);
           shouldStageFiles.add(relative(rootDir, filePath));
         }
       }
@@ -156,9 +158,11 @@ export class DefaultCommand extends Command<FrolintContext> {
       }> => Boolean(result))
       .forEach(({ filePath, output }) => {
         if (output) {
+          log("File (%s) has changed. Overwriting..", filePath);
           writeFileSync(filePath, output);
 
           if (!this.noStage && isFullyStaged(filePath)) {
+            log("File (%s) should be staged", filePath);
             shouldStageFiles.add(relative(rootDir, filePath));
           }
         }

--- a/packages/frolint/src/commands/ExportCommand.ts
+++ b/packages/frolint/src/commands/ExportCommand.ts
@@ -13,13 +13,22 @@ export class ExportCommand extends Command<FrolintContext> {
 
   @Command.Path("export")
   public async execute() {
-    const rootDir = getGitRootDir(this.context.cwd);
+    const log = this.context.debug("ExportCommand");
 
+    log("Start to execute");
+
+    const rootDir = getGitRootDir(this.context.cwd);
     const eslintrcPath = resolve(rootDir, ".eslintrc");
 
     try {
+      log("Check ESLint config file existence");
+
       accessSync(eslintrcPath, constants.R_OK);
+
+      log("ESLint config file found: %s", eslintrcPath);
     } catch (err) {
+      log("ESLint config file not found");
+
       if (err && (err as NodeJS.ErrnoException).code === "ENOENT") {
         const eslintrcContent = `{
   "extends": ["wantedly-typescript"],
@@ -28,6 +37,8 @@ export class ExportCommand extends Command<FrolintContext> {
   }
 }`;
 
+        log("Export ESLint config file");
+
         writeFileSync(eslintrcPath, eslintrcContent);
       }
     }
@@ -35,13 +46,23 @@ export class ExportCommand extends Command<FrolintContext> {
     const prettierrcPath = resolve(rootDir, ".prettierrc");
 
     try {
+      log("Check Prettier config file existence");
+
       accessSync(prettierrcPath, constants.R_OK);
+
+      log("Prettier config file found: %s", prettierrcPath);
     } catch (err) {
+      log("Prettier config file not found");
+
       if (err && (err as NodeJS.ErrnoException).code === "ENOENT") {
         const prettierrcContent = `"prettier-config-wantedly"\n`;
+
+        log("Export Prettier config file");
 
         writeFileSync(prettierrcPath, prettierrcContent);
       }
     }
+
+    log("Execution finished");
   }
 }

--- a/packages/frolint/src/commands/HelpCommand.ts
+++ b/packages/frolint/src/commands/HelpCommand.ts
@@ -6,7 +6,11 @@ export class HelpCommand extends Command<FrolintContext> {
   @Command.Path("--help")
   @Command.Path("-h")
   public async execute() {
+    const log = this.context.debug("HelpCommand");
+
+    log("Start to execute");
     this.context.stdout.write(this.cli.usage(null));
     this.context.stdout.write(this.cli.usage(DefaultCommand, { detailed: true }));
+    log("Execution finished");
   }
 }

--- a/packages/frolint/src/commands/PreCommitCommand.ts
+++ b/packages/frolint/src/commands/PreCommitCommand.ts
@@ -7,6 +7,9 @@ export class PreCommitCommand extends Command<FrolintContext> {
 
   @Command.Path("pre-commit")
   public async execute() {
+    const log = this.context.debug("PreCommitCommand");
+
+    log("pre-commit hook execution. Delegate operation to DefaultCommand");
     return await this.cli.run([], { preCommit: true });
   }
 }

--- a/packages/frolint/src/commands/PrintConfigCommand.ts
+++ b/packages/frolint/src/commands/PrintConfigCommand.ts
@@ -12,7 +12,18 @@ export class PrintConfigCommand extends Command<FrolintContext> {
 
   @Command.Path("print-config")
   public async execute() {
+    const log = this.context.debug("PrintConfigCommand");
+
+    log("Start to execute");
+    log("Print config context: %o", {
+      cwd: this.context.cwd,
+      eslintConfig: this.context.config.eslint,
+      filepath: this.filepath,
+    });
+
     const config = getCLI(this.context.cwd, undefined, this.context.config.eslint).getConfigForFile(this.filepath);
     console.log(JSON.stringify(config, null, "  "));
+
+    log("Exection finished");
   }
 }

--- a/packages/frolint/src/commands/VersionCommand.ts
+++ b/packages/frolint/src/commands/VersionCommand.ts
@@ -9,6 +9,12 @@ export class VersionCommand extends Command<FrolintContext> {
   @Command.Path("-v")
   @Command.Path("--version")
   public async execute() {
+    const log = this.context.debug("VersionCommand");
+
+    log("Start to execute");
     this.context.stdout.write(`${this.context.version}\n`);
+    log("Execution finished");
+
+    return 0;
   }
 }

--- a/packages/frolint/src/utils/debug.ts
+++ b/packages/frolint/src/utils/debug.ts
@@ -1,0 +1,3 @@
+import debug from "debug";
+
+export const frolintDebug = debug("frolint");

--- a/packages/frolint/src/utils/eslint.ts
+++ b/packages/frolint/src/utils/eslint.ts
@@ -2,25 +2,58 @@ import { CLIEngine } from "eslint";
 import { resolve } from "path";
 import { sync } from "resolve";
 import type { FrolintConfig } from "../Context";
+import { frolintDebug } from "./debug";
+
+const log = frolintDebug.extend("eslint");
 
 function detectReactVersion(basedir: string) {
+  log("detect react version: basedir=%s", basedir);
+
   try {
+    log("Resolve installed react package path");
+
     const reactPath = sync("react", { basedir });
+    log("Resolved react package path: %s", reactPath);
+
+    log("Require actual react");
     const react = require(reactPath);
+
+    log("Resolved react package version: %s", react.version);
     return react.version;
   } catch (e) {
+    log("Cannot resolve react");
     return null;
   }
 }
+
+let cliInstance: CLIEngine | null = null;
 
 export function getCLI(
   rootDir: string,
   eslintConfigPackage = "eslint-config-wantedly-typescript",
   eslintConfig: FrolintConfig["eslint"] = {}
 ) {
+  log("Retrieve ESLint CLI instance");
+
+  if (cliInstance) {
+    log("Cached CLI instance found");
+    return cliInstance;
+  }
+
+  log("Cached CLI instance not found. Create new CLI instance");
+
   const reactVersion = detectReactVersion(rootDir);
+
+  log("This project has react version %o", { reactVersion });
+
   const isReact = !!reactVersion;
+
+  log("Resolve proper ESLint config");
+
   const netEslintConfigPackage = eslintConfigPackage.replace("eslint-config-", "") + (isReact ? "" : "/without-react");
+
+  log("Proper ESLint config %o", { netEslintConfigPackage });
+
   const reactSettings = reactVersion
     ? {
         react: {
@@ -29,17 +62,20 @@ export function getCLI(
       }
     : {};
   const cacheLocation = resolve(rootDir, "node_modules", ".frolintcache");
-
-  const cli = new CLIEngine({
+  const options: CLIEngine.Options = {
     baseConfig: { extends: [netEslintConfigPackage], settings: { ...reactSettings } },
     fix: true,
     cwd: rootDir,
     ignorePath: eslintConfig.ignorePath,
     cache: true,
     cacheLocation,
-  });
+  };
 
-  return cli;
+  log("Create CLI instance with options: %O", options);
+
+  cliInstance = new CLIEngine(options);
+
+  return cliInstance;
 }
 
 function isSupportedExtension(file: string) {
@@ -53,5 +89,8 @@ export function applyEslint(
   eslintConfig: FrolintConfig["eslint"]
 ) {
   const cli = getCLI(rootDir, eslintConfigPackage, eslintConfig);
+
+  log("Applying ESLint linter and fixer");
+
   return cli.executeOnFiles(files.filter(isSupportedExtension).filter((file) => !cli.isPathIgnored(file)));
 }

--- a/packages/frolint/src/utils/prettier.ts
+++ b/packages/frolint/src/utils/prettier.ts
@@ -4,6 +4,9 @@ import type { BuiltInParserName, ResolveConfigOptions } from "prettier";
 import prettier from "prettier";
 import prettierConfigWantedly from "prettier-config-wantedly";
 import type { FrolintConfig } from "../Context";
+import { frolintDebug } from "./debug";
+
+const log = frolintDebug.extend("prettier");
 
 const supportedLanguages = [
   "JavaScript",
@@ -36,6 +39,9 @@ function isIgnoredForPrettier(file: string, prettierConfig: FrolintConfig["prett
 }
 
 export function applyPrettier(rootDir: string, files: string[], prettierConfig: FrolintConfig["prettier"]) {
+  log("Supported languages by Prettier: %O", { supportedLanguages, supportedExtensions });
+  log("Prettier config: %O", { prettierConfig });
+
   return files
     .filter((file) => isPrettierSupported(file))
     .filter((file) => !isIgnoredForPrettier(file, prettierConfig))

--- a/packages/frolint/src/utils/report.ts
+++ b/packages/frolint/src/utils/report.ts
@@ -1,22 +1,27 @@
 import chalk from "chalk";
 import type { CLIEngine } from "eslint";
 import { relative } from "path";
+import { frolintDebug } from "./debug";
 import { getCLI } from "./eslint";
 
 const { green, red, yellow } = chalk;
+const log = frolintDebug.extend("report");
 
 function reportNoop() {
   console.log(green("No errors and warnings!"));
 }
 
 function reportWithFrolintFormat(report: CLIEngine.LintReport, rootDir: string) {
+  log("Start reporting using frolint format");
   const { results, errorCount, warningCount } = report;
 
   if (errorCount === 0 && warningCount === 0) {
+    log("No errors and warnings");
     reportNoop();
     return [];
   }
 
+  log("Some errors and warnings found: %o", { errorCount, warningCount });
   const total = `Detected ${red(errorCount.toString(), errorCount === 1 ? "error" : "errors")}, ${yellow(
     warningCount.toString(),
     warningCount === 1 ? "warning" : "warnings"
@@ -25,6 +30,8 @@ function reportWithFrolintFormat(report: CLIEngine.LintReport, rootDir: string) 
 
   const reported = formatResults(results, rootDir);
   reported.forEach(({ filePath, errorCount, warningCount, messages }) => {
+    log("Start printing report for %s", filePath);
+
     const colored = `${green(["./", filePath].join(""))}: ${red(
       errorCount.toString(),
       errorCount === 1 ? "error" : "errors"
@@ -41,6 +48,8 @@ function reportWithFrolintFormat(report: CLIEngine.LintReport, rootDir: string) 
 }
 
 function formatResults(results: CLIEngine.LintResult[], rootDir: string) {
+  log("Format ESLint error results");
+
   return results
     .filter(({ errorCount, warningCount }) => errorCount > 0 || warningCount > 0)
     .map(({ filePath, ...rest }) => {
@@ -53,6 +62,8 @@ function formatResults(results: CLIEngine.LintResult[], rootDir: string) {
 
 export function reportToConsole(report: CLIEngine.LintReport, rootDir: string, formatter?: string) {
   if (formatter) {
+    log("Start reporting using ESLint provided format: %o", { formatter });
+
     const cli = getCLI(rootDir);
     const format = cli.getFormatter(formatter);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1676,6 +1676,11 @@
   dependencies:
     cosmiconfig "*"
 
+"@types/debug@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
+  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
+
 "@types/eslint@^7.2.6":
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.6.tgz#5e9aff555a975596c03a98b59ecd103decc70c3c"
@@ -3508,7 +3513,7 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==


### PR DESCRIPTION
## Why & What

In some case, I want to debug the behaviour of `frolint` but we cannot see debug log. So I introduce `debug` package and to debug the behaviour.

```
$ DEBUG=frolint:* yarn frolint
```

![image](https://user-images.githubusercontent.com/7839872/101717643-09b86a00-3ae3-11eb-95ba-519d70242464.png)
