### PR TITLE
Use `ESLint` class instead of `CLIEngine`

### DIFF
--- a/packages/frolint/src/commands/DefaultCommand.ts
+++ b/packages/frolint/src/commands/DefaultCommand.ts
@@ -132,8 +132,8 @@ export class DefaultCommand extends Command<FrolintContext> {
     /**
      * Apply ESLint step
      */
-    const report = applyEslint(rootDir, files, eslintConfigPackage, this.context.config.eslint);
-    report.results.forEach((result) => {
+    const results = await applyEslint(rootDir, files, eslintConfigPackage, this.context.config.eslint);
+    results.forEach((result) => {
       const { filePath, output } = result;
       if (output) {
         log("File (%s) has changed. Overwriting..", filePath);
@@ -150,8 +150,8 @@ export class DefaultCommand extends Command<FrolintContext> {
     /**
      * Apply Prettier step
      */
-    const results = applyPrettier(rootDir, files, this.context.config.prettier);
-    results
+    const prettierResults = applyPrettier(rootDir, files, this.context.config.prettier);
+    prettierResults
       .filter((result: { filePath: string; output: string } | null): result is Required<{
         filePath: string;
         output: string;
@@ -177,7 +177,7 @@ export class DefaultCommand extends Command<FrolintContext> {
     }
 
     log("Start reporting results to console");
-    const reported = reportToConsole(report, rootDir, this.context.config.formatter || this.formatter);
+    const reported = await reportToConsole(results, rootDir, this.context.config.formatter || this.formatter);
 
     if (!noGit && this.context.preCommit) {
       const stagedErrorCount = reported

--- a/packages/frolint/src/commands/PrintConfigCommand.ts
+++ b/packages/frolint/src/commands/PrintConfigCommand.ts
@@ -21,7 +21,9 @@ export class PrintConfigCommand extends Command<FrolintContext> {
       filepath: this.filepath,
     });
 
-    const config = getCLI(this.context.cwd, undefined, this.context.config.eslint).getConfigForFile(this.filepath);
+    const config = await getCLI(this.context.cwd, undefined, this.context.config.eslint).calculateConfigForFile(
+      this.filepath
+    );
     console.log(JSON.stringify(config, null, "  "));
 
     log("Exection finished");

--- a/packages/frolint/src/index.ts
+++ b/packages/frolint/src/index.ts
@@ -56,16 +56,17 @@ if (result && result.config) {
 log("Frolint config: %o", config);
 log("Start to run CLI");
 
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-cli.runExit(process.argv.slice(2), {
-  ...Cli.defaultContext,
-  cwd: process.cwd(),
-  config,
-  preCommit: false,
-  version: binaryVersion,
-  debug: (namespace) => {
-    return frolintDebug.extend(namespace);
-  },
-});
-
-log("Linting and Formatting complete");
+void cli
+  .runExit(process.argv.slice(2), {
+    ...Cli.defaultContext,
+    cwd: process.cwd(),
+    config,
+    preCommit: false,
+    version: binaryVersion,
+    debug: (namespace) => {
+      return frolintDebug.extend(namespace);
+    },
+  })
+  .then(() => {
+    log("Linting and Formatting complete");
+  });

--- a/packages/frolint/src/utils/prettier.ts
+++ b/packages/frolint/src/utils/prettier.ts
@@ -42,9 +42,13 @@ export function applyPrettier(rootDir: string, files: string[], prettierConfig: 
   log("Supported languages by Prettier: %O", { supportedLanguages, supportedExtensions });
   log("Prettier config: %O", { prettierConfig });
 
-  return files
+  const targetFiles = files
     .filter((file) => isPrettierSupported(file))
-    .filter((file) => !isIgnoredForPrettier(file, prettierConfig))
+    .filter((file) => !isIgnoredForPrettier(file, prettierConfig));
+
+  log("Applying Prettier. target files: %O", targetFiles);
+
+  return targetFiles
     .map((file) => {
       const filePath = resolve(rootDir, file);
       const options = prettierConfig.config


### PR DESCRIPTION
## Why

`CLIEngine` class is deprecated. So use `ESLint` class.

> https://eslint.org/blog/2020/05/eslint-v7.0.0-released#new-eslint-class
The CLIEngine class provides a synchronous API that is blocking the implementation of features such as parallel linting, supporting ES modules in shareable configs/parsers/plugins/formatters, and adding the ability to visually display the progress of linting runs. The new ESLint class provides an asynchronous API that ESLint core will now using going forward. CLIEngine will remain in core for the foreseeable future but may be removed in a future major version.


## What

Rewrite some commands and utils using `async/await`