### PR TITLE
Remove CLIEngine from tests in eslint-config-wantedly

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "postinstall": "lerna bootstrap",
     "test": "FORCE_COLOR=1 lerna run --stream test",
-    "test:watch": "FORCE_COLOR=1 lerna exec --stream -- npm run test -- --watch",
+    "test:watch": "FORCE_COLOR=1 lerna exec --stream --ignore prettier-config-wantedly -- npm run test -- --watch",
     "test:watch:frolint": "lerna exec \"npm run test -- --watch\" --scope frolint",
     "test:update": "lerna run --stream test -- -u",
     "lint": "frolint --branch master",

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`eslint-config-wantedly-typescript should match snapshot for env 1`] = `
+exports[`eslint-config-wantedly-typescript should match snapshot for: env 1`] = `
 Object {
   "browser": true,
   "es6": true,
@@ -9,19 +9,19 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly-typescript should match snapshot for globals 1`] = `
+exports[`eslint-config-wantedly-typescript should match snapshot for: globals 1`] = `
 Object {
   "flushPromises": true,
 }
 `;
 
-exports[`eslint-config-wantedly-typescript should match snapshot for ignorePatterns 1`] = `Array []`;
+exports[`eslint-config-wantedly-typescript should match snapshot for: ignorePatterns 1`] = `Array []`;
 
-exports[`eslint-config-wantedly-typescript should match snapshot for noInlineConfig 1`] = `undefined`;
+exports[`eslint-config-wantedly-typescript should match snapshot for: noInlineConfig 1`] = `undefined`;
 
-exports[`eslint-config-wantedly-typescript should match snapshot for parser 1`] = `"/@typescript-eslint/parser/dist/index.js"`;
+exports[`eslint-config-wantedly-typescript should match snapshot for: parser 1`] = `"/@typescript-eslint/parser/dist/index.js"`;
 
-exports[`eslint-config-wantedly-typescript should match snapshot for parserOptions 1`] = `
+exports[`eslint-config-wantedly-typescript should match snapshot for: parserOptions 1`] = `
 Object {
   "ecmaFeatures": Object {
     "experimentalObjectRestSpread": true,
@@ -31,7 +31,7 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly-typescript should match snapshot for plugins 1`] = `
+exports[`eslint-config-wantedly-typescript should match snapshot for: plugins 1`] = `
 Array [
   "wantedly",
   "react-hooks",
@@ -45,9 +45,9 @@ Array [
 ]
 `;
 
-exports[`eslint-config-wantedly-typescript should match snapshot for reportUnusedDisableDirectives 1`] = `undefined`;
+exports[`eslint-config-wantedly-typescript should match snapshot for: reportUnusedDisableDirectives 1`] = `undefined`;
 
-exports[`eslint-config-wantedly-typescript should match snapshot for rules 1`] = `
+exports[`eslint-config-wantedly-typescript should match snapshot for: rules 1`] = `
 Object {
   "@typescript-eslint/adjacent-overload-signatures": Array [
     "error",
@@ -857,4 +857,4 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly-typescript should match snapshot for settings 1`] = `Object {}`;
+exports[`eslint-config-wantedly-typescript should match snapshot for: settings 1`] = `Object {}`;

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`eslint-config-wantedly-typescript/without-react should match snapshot for env 1`] = `
+exports[`eslint-config-wantedly-typescript/without-react should match snapshot for: env 1`] = `
 Object {
   "browser": true,
   "es6": true,
@@ -9,19 +9,19 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly-typescript/without-react should match snapshot for globals 1`] = `
+exports[`eslint-config-wantedly-typescript/without-react should match snapshot for: globals 1`] = `
 Object {
   "flushPromises": true,
 }
 `;
 
-exports[`eslint-config-wantedly-typescript/without-react should match snapshot for ignorePatterns 1`] = `Array []`;
+exports[`eslint-config-wantedly-typescript/without-react should match snapshot for: ignorePatterns 1`] = `Array []`;
 
-exports[`eslint-config-wantedly-typescript/without-react should match snapshot for noInlineConfig 1`] = `undefined`;
+exports[`eslint-config-wantedly-typescript/without-react should match snapshot for: noInlineConfig 1`] = `undefined`;
 
-exports[`eslint-config-wantedly-typescript/without-react should match snapshot for parser 1`] = `"/@typescript-eslint/parser/dist/index.js"`;
+exports[`eslint-config-wantedly-typescript/without-react should match snapshot for: parser 1`] = `"/@typescript-eslint/parser/dist/index.js"`;
 
-exports[`eslint-config-wantedly-typescript/without-react should match snapshot for parserOptions 1`] = `
+exports[`eslint-config-wantedly-typescript/without-react should match snapshot for: parserOptions 1`] = `
 Object {
   "ecmaFeatures": Object {
     "experimentalObjectRestSpread": true,
@@ -31,7 +31,7 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly-typescript/without-react should match snapshot for plugins 1`] = `
+exports[`eslint-config-wantedly-typescript/without-react should match snapshot for: plugins 1`] = `
 Array [
   "use-macros",
   "@typescript-eslint",
@@ -42,9 +42,9 @@ Array [
 ]
 `;
 
-exports[`eslint-config-wantedly-typescript/without-react should match snapshot for reportUnusedDisableDirectives 1`] = `undefined`;
+exports[`eslint-config-wantedly-typescript/without-react should match snapshot for: reportUnusedDisableDirectives 1`] = `undefined`;
 
-exports[`eslint-config-wantedly-typescript/without-react should match snapshot for rules 1`] = `
+exports[`eslint-config-wantedly-typescript/without-react should match snapshot for: rules 1`] = `
 Object {
   "@typescript-eslint/adjacent-overload-signatures": Array [
     "error",
@@ -725,4 +725,4 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly-typescript/without-react should match snapshot for settings 1`] = `Object {}`;
+exports[`eslint-config-wantedly-typescript/without-react should match snapshot for: settings 1`] = `Object {}`;

--- a/packages/eslint-config-wantedly-typescript/__tests__/index.test.js
+++ b/packages/eslint-config-wantedly-typescript/__tests__/index.test.js
@@ -1,21 +1,18 @@
-const path = require("path");
-const CLIEngine = require("eslint").CLIEngine;
-
-const ESLINT_CONFIG_FILE = path.resolve(__dirname, "..", "index.js");
-const engine = new CLIEngine({
-  configFile: ESLINT_CONFIG_FILE,
-  useEslintrc: false,
-});
+const ESLint = require("eslint").ESLint;
+const baseConfig = require("../index");
 
 const normalizePath = (path) => {
   return /node_modules/.test(path) ? path.split("node_modules")[1] : path;
 };
 
 describe("eslint-config-wantedly-typescript", () => {
-  const config = engine.getConfigForFile("test.ts");
-  const keys = Object.keys(config);
+  test("should match snapshot for", async () => {
+    const config = await new ESLint({
+      baseConfig,
+      useEslintrc: false,
+    }).calculateConfigForFile("test.ts");
+    const keys = Object.keys(config);
 
-  beforeAll(() => {
     const normalizeRequiredKeys = ["extends", "parser"];
     normalizeRequiredKeys.forEach((key) => {
       const newConfig = config[key];
@@ -26,11 +23,9 @@ describe("eslint-config-wantedly-typescript", () => {
         config[key] = normalizePath(newConfig);
       }
     });
-  });
 
-  keys.forEach((key) => {
-    test(`should match snapshot for ${key}`, () => {
-      expect(config[key]).toMatchSnapshot();
+    keys.forEach((key) => {
+      expect(config[key]).toMatchSnapshot(key);
     });
   });
 });

--- a/packages/eslint-config-wantedly-typescript/__tests__/without-react.test.js
+++ b/packages/eslint-config-wantedly-typescript/__tests__/without-react.test.js
@@ -1,21 +1,18 @@
-const path = require("path");
-const CLIEngine = require("eslint").CLIEngine;
-
-const ESLINT_CONFIG_FILE = path.resolve(__dirname, "..", "without-react.js");
-const engine = new CLIEngine({
-  configFile: ESLINT_CONFIG_FILE,
-  useEslintrc: false,
-});
+const ESLint = require("eslint").ESLint;
+const baseConfig = require("../without-react");
 
 const normalizePath = (path) => {
   return /node_modules/.test(path) ? path.split("node_modules")[1] : path;
 };
 
 describe("eslint-config-wantedly-typescript/without-react", () => {
-  const config = engine.getConfigForFile("test.ts");
-  const keys = Object.keys(config);
+  test("should match snapshot for", async () => {
+    const config = await new ESLint({
+      baseConfig,
+      useEslintrc: false,
+    }).calculateConfigForFile("test.ts");
+    const keys = Object.keys(config);
 
-  beforeAll(() => {
     const normalizeRequiredKeys = ["extends", "parser"];
     normalizeRequiredKeys.forEach((key) => {
       const newConfig = config[key];
@@ -26,11 +23,9 @@ describe("eslint-config-wantedly-typescript/without-react", () => {
         config[key] = normalizePath(newConfig);
       }
     });
-  });
 
-  keys.forEach((key) => {
-    test(`should match snapshot for ${key}`, () => {
-      expect(config[key]).toMatchSnapshot();
+    keys.forEach((key) => {
+      expect(config[key]).toMatchSnapshot(key);
     });
   });
 });

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`eslint-config-wantedly should match snapshot for env 1`] = `
+exports[`eslint-config-wantedly should match snapshot for: env 1`] = `
 Object {
   "browser": true,
   "es6": true,
@@ -9,19 +9,19 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly should match snapshot for globals 1`] = `
+exports[`eslint-config-wantedly should match snapshot for: globals 1`] = `
 Object {
   "flushPromises": true,
 }
 `;
 
-exports[`eslint-config-wantedly should match snapshot for ignorePatterns 1`] = `Array []`;
+exports[`eslint-config-wantedly should match snapshot for: ignorePatterns 1`] = `Array []`;
 
-exports[`eslint-config-wantedly should match snapshot for noInlineConfig 1`] = `undefined`;
+exports[`eslint-config-wantedly should match snapshot for: noInlineConfig 1`] = `undefined`;
 
-exports[`eslint-config-wantedly should match snapshot for parser 1`] = `"/babel-eslint/lib/index.js"`;
+exports[`eslint-config-wantedly should match snapshot for: parser 1`] = `"/babel-eslint/lib/index.js"`;
 
-exports[`eslint-config-wantedly should match snapshot for parserOptions 1`] = `
+exports[`eslint-config-wantedly should match snapshot for: parserOptions 1`] = `
 Object {
   "ecmaFeatures": Object {
     "experimentalObjectRestSpread": true,
@@ -31,7 +31,7 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly should match snapshot for plugins 1`] = `
+exports[`eslint-config-wantedly should match snapshot for: plugins 1`] = `
 Array [
   "react-hooks",
   "react",
@@ -43,9 +43,9 @@ Array [
 ]
 `;
 
-exports[`eslint-config-wantedly should match snapshot for reportUnusedDisableDirectives 1`] = `undefined`;
+exports[`eslint-config-wantedly should match snapshot for: reportUnusedDisableDirectives 1`] = `undefined`;
 
-exports[`eslint-config-wantedly should match snapshot for rules 1`] = `
+exports[`eslint-config-wantedly should match snapshot for: rules 1`] = `
 Object {
   "array-bracket-newline": Array [
     "off",
@@ -735,4 +735,4 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly should match snapshot for settings 1`] = `Object {}`;
+exports[`eslint-config-wantedly should match snapshot for: settings 1`] = `Object {}`;

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`eslint-config-wantedly/without-react should match snapshot for env 1`] = `
+exports[`eslint-config-wantedly/without-react should match snapshot for: env 1`] = `
 Object {
   "browser": true,
   "es6": true,
@@ -9,19 +9,19 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly/without-react should match snapshot for globals 1`] = `
+exports[`eslint-config-wantedly/without-react should match snapshot for: globals 1`] = `
 Object {
   "flushPromises": true,
 }
 `;
 
-exports[`eslint-config-wantedly/without-react should match snapshot for ignorePatterns 1`] = `Array []`;
+exports[`eslint-config-wantedly/without-react should match snapshot for: ignorePatterns 1`] = `Array []`;
 
-exports[`eslint-config-wantedly/without-react should match snapshot for noInlineConfig 1`] = `undefined`;
+exports[`eslint-config-wantedly/without-react should match snapshot for: noInlineConfig 1`] = `undefined`;
 
-exports[`eslint-config-wantedly/without-react should match snapshot for parser 1`] = `"/babel-eslint/lib/index.js"`;
+exports[`eslint-config-wantedly/without-react should match snapshot for: parser 1`] = `"/babel-eslint/lib/index.js"`;
 
-exports[`eslint-config-wantedly/without-react should match snapshot for parserOptions 1`] = `
+exports[`eslint-config-wantedly/without-react should match snapshot for: parserOptions 1`] = `
 Object {
   "ecmaFeatures": Object {
     "experimentalObjectRestSpread": true,
@@ -31,7 +31,7 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly/without-react should match snapshot for plugins 1`] = `
+exports[`eslint-config-wantedly/without-react should match snapshot for: plugins 1`] = `
 Array [
   "use-macros",
   "prettier",
@@ -41,9 +41,9 @@ Array [
 ]
 `;
 
-exports[`eslint-config-wantedly/without-react should match snapshot for reportUnusedDisableDirectives 1`] = `undefined`;
+exports[`eslint-config-wantedly/without-react should match snapshot for: reportUnusedDisableDirectives 1`] = `undefined`;
 
-exports[`eslint-config-wantedly/without-react should match snapshot for rules 1`] = `
+exports[`eslint-config-wantedly/without-react should match snapshot for: rules 1`] = `
 Object {
   "array-bracket-newline": Array [
     "off",
@@ -607,4 +607,4 @@ Object {
 }
 `;
 
-exports[`eslint-config-wantedly/without-react should match snapshot for settings 1`] = `Object {}`;
+exports[`eslint-config-wantedly/without-react should match snapshot for: settings 1`] = `Object {}`;

--- a/packages/eslint-config-wantedly/__tests__/index.test.js
+++ b/packages/eslint-config-wantedly/__tests__/index.test.js
@@ -1,21 +1,18 @@
-const path = require("path");
-const CLIEngine = require("eslint").CLIEngine;
-
-const ESLINT_CONFIG_FILE = path.resolve(__dirname, "..", "index.js");
-const engine = new CLIEngine({
-  configFile: ESLINT_CONFIG_FILE,
-  useEslintrc: false,
-});
+const ESLint = require("eslint").ESLint;
+const baseConfig = require("../index");
 
 const normalizePath = (path) => {
   return /node_modules/.test(path) ? path.split("node_modules")[1] : path;
 };
 
 describe("eslint-config-wantedly", () => {
-  const config = engine.getConfigForFile("test.js");
-  const keys = Object.keys(config);
+  test("should match snapshot for", async () => {
+    const config = await new ESLint({
+      baseConfig,
+      useEslintrc: false,
+    }).calculateConfigForFile("test.js");
+    const keys = Object.keys(config);
 
-  beforeAll(() => {
     const normalizeRequiredKeys = ["extends", "parser"];
     normalizeRequiredKeys.forEach((key) => {
       const newConfig = config[key];
@@ -26,11 +23,9 @@ describe("eslint-config-wantedly", () => {
         config[key] = normalizePath(newConfig);
       }
     });
-  });
 
-  keys.forEach((key) => {
-    test(`should match snapshot for ${key}`, () => {
-      expect(config[key]).toMatchSnapshot();
+    keys.forEach((key) => {
+      expect(config[key]).toMatchSnapshot(key);
     });
   });
 });

--- a/packages/eslint-config-wantedly/__tests__/without-react.test.js
+++ b/packages/eslint-config-wantedly/__tests__/without-react.test.js
@@ -1,21 +1,18 @@
-const path = require("path");
-const CLIEngine = require("eslint").CLIEngine;
-
-const ESLINT_CONFIG_FILE = path.resolve(__dirname, "..", "without-react.js");
-const engine = new CLIEngine({
-  configFile: ESLINT_CONFIG_FILE,
-  useEslintrc: false,
-});
+const ESLint = require("eslint").ESLint;
+const baseConfig = require("../without-react");
 
 const normalizePath = (path) => {
   return /node_modules/.test(path) ? path.split("node_modules")[1] : path;
 };
 
 describe("eslint-config-wantedly/without-react", () => {
-  const config = engine.getConfigForFile("test.js");
-  const keys = Object.keys(config);
+  test("should match snapshot for", async () => {
+    const config = await new ESLint({
+      baseConfig,
+      useEslintrc: false,
+    }).calculateConfigForFile("test.js");
+    const keys = Object.keys(config);
 
-  beforeAll(() => {
     const normalizeRequiredKeys = ["extends", "parser"];
     normalizeRequiredKeys.forEach((key) => {
       const newConfig = config[key];
@@ -26,11 +23,9 @@ describe("eslint-config-wantedly/without-react", () => {
         config[key] = normalizePath(newConfig);
       }
     });
-  });
 
-  keys.forEach((key) => {
-    test(`should match snapshot for ${key}`, () => {
-      expect(config[key]).toMatchSnapshot();
+    keys.forEach((key) => {
+      expect(config[key]).toMatchSnapshot(key);
     });
   });
 });


### PR DESCRIPTION
## Why & What

Remove `CLIEngine` class usage from test files because of deprecation.
