### PR TITLE
Use eqeqeq rule smart option

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -259,6 +259,7 @@ Object {
   ],
   "eqeqeq": Array [
     "error",
+    "smart",
   ],
   "for-direction": Array [
     "error",

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
@@ -256,6 +256,7 @@ Object {
   ],
   "eqeqeq": Array [
     "error",
+    "smart",
   ],
   "for-direction": Array [
     "error",

--- a/packages/eslint-config-wantedly-typescript/without-react.js
+++ b/packages/eslint-config-wantedly-typescript/without-react.js
@@ -114,7 +114,7 @@ module.exports = {
     "use-isnan": "error",
     "valid-typeof": "error",
     camelcase: ["error", { ignoreDestructuring: true, properties: "never" }],
-    eqeqeq: "error",
+    eqeqeq: ["error", "smart"],
     indent: "off",
     quotes: ["off"],
     semi: "off",

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -126,6 +126,7 @@ Object {
   ],
   "eqeqeq": Array [
     "error",
+    "smart",
   ],
   "for-direction": Array [
     "error",

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
@@ -124,6 +124,7 @@ Object {
   ],
   "eqeqeq": Array [
     "error",
+    "smart",
   ],
   "for-direction": Array [
     "error",

--- a/packages/eslint-config-wantedly/without-react.js
+++ b/packages/eslint-config-wantedly/without-react.js
@@ -121,7 +121,7 @@ module.exports = {
     "use-isnan": "error",
     "valid-typeof": "error",
     camelcase: ["error", { ignoreDestructuring: false, properties: "never" }],
-    eqeqeq: "error",
+    eqeqeq: ["error", "smart"],
     indent: "off",
     quotes: ["off"],
     semi: ["error", "always"],


### PR DESCRIPTION
## Why & What

Now our `eqeqeq` rule is set as `"error"`. But the code below will be pointed out with an error.

```js
a == null // check the a is not null or undefined
```

We should enable the [`smart`](https://eslint.org/docs/rules/eqeqeq#smart) option for `eqeqeq` rule.