### PR TITLE
Prevent false positive when the user uses React 17

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -698,7 +698,7 @@ Object {
     2,
   ],
   "react/jsx-uses-react": Array [
-    2,
+    "off",
   ],
   "react/jsx-uses-vars": Array [
     "error",
@@ -755,7 +755,7 @@ Object {
     "off",
   ],
   "react/react-in-jsx-scope": Array [
-    2,
+    "off",
   ],
   "react/require-default-props": Array [
     "off",

--- a/packages/eslint-config-wantedly-typescript/index.js
+++ b/packages/eslint-config-wantedly-typescript/index.js
@@ -19,6 +19,7 @@ module.exports = {
     "react/jsx-no-bind": ["warn", { allowArrowFunctions: true }],
     "react/jsx-no-duplicate-props": "error",
     "react/jsx-no-target-blank": "warn",
+    "react/jsx-uses-react": ["off"],
     "react/jsx-uses-vars": "error",
     "react/jsx-wrap-multilines": "warn",
     "react/no-array-index-key": "error",
@@ -28,6 +29,7 @@ module.exports = {
     "react/no-string-refs": "error",
     "react/no-unused-prop-types": "off",
     "react/prop-types": "off",
+    "react/react-in-jsx-scope": ["off"],
     "react/require-default-props": "off",
 
     // eslint-plugin-react-hooks rules

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -578,7 +578,7 @@ Object {
     2,
   ],
   "react/jsx-uses-react": Array [
-    2,
+    "off",
   ],
   "react/jsx-uses-vars": Array [
     "error",
@@ -635,7 +635,7 @@ Object {
     "off",
   ],
   "react/react-in-jsx-scope": Array [
-    2,
+    "off",
   ],
   "react/require-default-props": Array [
     "off",

--- a/packages/eslint-config-wantedly/index.js
+++ b/packages/eslint-config-wantedly/index.js
@@ -19,6 +19,7 @@ module.exports = {
     "react/jsx-no-bind": ["warn", { allowArrowFunctions: true }],
     "react/jsx-no-duplicate-props": "error",
     "react/jsx-no-target-blank": "warn",
+    "react/jsx-uses-react": ["off"],
     "react/jsx-uses-vars": "error",
     "react/jsx-wrap-multilines": "warn",
     "react/no-array-index-key": "error",
@@ -28,6 +29,7 @@ module.exports = {
     "react/no-string-refs": "error",
     "react/no-unused-prop-types": "off",
     "react/prop-types": "off",
+    "react/react-in-jsx-scope": ["off"],
     "react/require-default-props": "off",
 
     // eslint-plugin-react-hooks rules


### PR DESCRIPTION
## Why

A [new JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) was introduced in React 17 and backported to React 16.14.0, 15.7.0, and 0.14.10, which enables people to use JSX features without having React in the scope. 

## What

We should disable some rules.

- [`react/jsx-uses-react`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md)
- [`react/react-in-jsx-scope`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md)