### PR TITLE
Relax peerDependencies to typescript

### DIFF
--- a/packages/eslint-config-wantedly-typescript/package.json
+++ b/packages/eslint-config-wantedly-typescript/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-wantedly": "^2.4.0"
   },
   "peerDependencies": {
-    "typescript": "^3.8.3"
+    "typescript": ">=3.3.1 <4.2.0"
   },
   "homepage": "https://github.com/wantedly/frolint",
   "keywords": [


### PR DESCRIPTION
## Why

We currently specify `"typescript": "^3.8.3"`, which obviously led to false positives in our repos.

## What

Specified `>=3.3.1 <4.2.0` from https://github.com/typescript-eslint/typescript-eslint/tree/v4.11.1#supported-typescript-version .