### PR TITLE
Replace no-redeclare with @typescript-eslint/no-redeclare

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -135,6 +135,9 @@ Object {
   "@typescript-eslint/no-non-null-assertion": Array [
     "warn",
   ],
+  "@typescript-eslint/no-redeclare": Array [
+    "error",
+  ],
   "@typescript-eslint/no-this-alias": Array [
     "error",
   ],
@@ -520,7 +523,7 @@ Object {
     },
   ],
   "no-redeclare": Array [
-    "error",
+    "off",
   ],
   "no-regex-spaces": Array [
     "error",

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
@@ -132,6 +132,9 @@ Object {
   "@typescript-eslint/no-non-null-assertion": Array [
     "warn",
   ],
+  "@typescript-eslint/no-redeclare": Array [
+    "error",
+  ],
   "@typescript-eslint/no-this-alias": Array [
     "error",
   ],
@@ -517,7 +520,7 @@ Object {
     },
   ],
   "no-redeclare": Array [
-    "error",
+    "off",
   ],
   "no-regex-spaces": Array [
     "error",

--- a/packages/eslint-config-wantedly-typescript/without-react.js
+++ b/packages/eslint-config-wantedly-typescript/without-react.js
@@ -89,7 +89,8 @@ module.exports = {
     "no-octal": "error",
     "no-param-reassign": "error",
     "no-plusplus": ["error", { allowForLoopAfterthoughts: true }],
-    "no-redeclare": "error",
+    // See @typescript-eslint/no-redeclare
+    "no-redeclare": "off",
     "no-regex-spaces": "error",
     "no-self-assign": "error",
     "no-shadow": "off",
@@ -131,6 +132,7 @@ module.exports = {
     "@typescript-eslint/no-array-constructor": "error",
     "@typescript-eslint/no-explicit-any": ["off"],
     "@typescript-eslint/no-floating-promises": ["error"],
+    "@typescript-eslint/no-redeclare": "error",
     "@typescript-eslint/no-unused-vars": [
       "error",
       { varsIgnorePattern: "^_", argsIgnorePattern: "^_", ignoreRestSiblings: true },


### PR DESCRIPTION
## Why

`no-redeclare` has false-positives for TypeScript-related constructions, such as overload declarations and declaration merging.

## What

Use `@typescript-eslint/no-redeclare` instead.