### PR TITLE
Use pull_request_target for labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Labeler"
 
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   triage:


### PR DESCRIPTION
## Why

CI is failing in dependabot PRs https://github.com/wantedly/frolint/pull/798

This is supposed to have been caused by [this change in GitHub](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/). That means, dependabot PRs are now considered the same as PRs from remote repositories, thus the action is unable to do write operations.

## What

Use `pull_request_target` for labeler. Unlike the `pull_request` event, this is run in the base branch's context. actions/labeler doesn't execute code from the head branch, so it's safe to execute in the `pull_request_target` context. In fact, the README of the action shows an example using `pull_request_target`.