### PR TITLE
Stop support Node.js 10.x and start to supoort 16.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Why & What

Node.js 10.x is end of life on 2021/04/30. And Node.js 16.x is released on 2021/04/20.

![image](https://user-images.githubusercontent.com/7839872/115648902-42096800-a361-11eb-837f-578c4b6705f4.png)
