### PR TITLE
Add ES2018 RegExp rules in eslint-plugin-es to prevent SyntaxError in IE and Safari

### DIFF
--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -35,6 +35,7 @@ exports[`eslint-config-wantedly should match snapshot for: plugins 1`] = `
 Array [
   "react-hooks",
   "react",
+  "es",
   "use-macros",
   "prettier",
   "jest",

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -188,6 +188,12 @@ Object {
     "error",
     "smart",
   ],
+  "es/no-regexp-lookbehind-assertions": Array [
+    "error",
+  ],
+  "es/no-regexp-named-capture-groups": Array [
+    "error",
+  ],
   "flowtype/boolean-style": Array [
     "off",
   ],

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
@@ -186,6 +186,12 @@ Object {
     "error",
     "smart",
   ],
+  "es/no-regexp-lookbehind-assertions": Array [
+    "error",
+  ],
+  "es/no-regexp-named-capture-groups": Array [
+    "error",
+  ],
   "flowtype/boolean-style": Array [
     "off",
   ],

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
@@ -33,6 +33,7 @@ Object {
 
 exports[`eslint-config-wantedly/without-react should match snapshot for: plugins 1`] = `
 Array [
+  "es",
   "use-macros",
   "prettier",
   "jest",

--- a/packages/eslint-config-wantedly/package.json
+++ b/packages/eslint-config-wantedly/package.json
@@ -7,6 +7,7 @@
     "babel-eslint": "^10.1.0",
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-es": "^4.1.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/packages/eslint-config-wantedly/without-react.js
+++ b/packages/eslint-config-wantedly/without-react.js
@@ -141,5 +141,9 @@ module.exports = {
 
     // eslint-plugin-use-macros rules
     "use-macros/graphql-tag": "error",
+
+    // eslint-plugin-es rules
+    "es/no-regexp-lookbehind-assertions": "error",
+    "es/no-regexp-named-capture-groups": "error",
   },
 };

--- a/packages/eslint-config-wantedly/without-react.js
+++ b/packages/eslint-config-wantedly/without-react.js
@@ -17,7 +17,7 @@ module.exports = {
     },
     sourceType: "module",
   },
-  plugins: ["import", "jsx-a11y", "jest", "prettier", "use-macros"],
+  plugins: ["import", "jsx-a11y", "jest", "prettier", "use-macros", "es"],
   rules: {
     "array-callback-return": "off",
     "arrow-body-style": ["off"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3468,6 +3468,14 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+eslint-plugin-es@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz#f0822f0c18a535a97c3e714e89f88586a7641ec9"
+  integrity sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
 eslint-plugin-import@^2.22.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"


### PR DESCRIPTION
## Why

IE and Safari do not support [RegExp Lookbehind Assertions](https://github.com/tc39/proposal-regexp-lookbehind) and IE does not support [RegExp Named Capture Groups](https://github.com/tc39/proposal-regexp-named-groups). 
Furthermore, [Babel does not transpire those RegExp features.
](https://qiita.com/ota-meshi/items/8d4c07b825f9392fe235)

refs:
- https://caniuse.com/js-regexp-lookbehind
- https://caniuse.com/mdn-javascript_builtins_regexp_named_capture_groups

The browsers throw SyntaxError when parsing those RegExp. This will crash the web page.


## What

Introduce [eslint-plugin-es](https://mysticatea.github.io/eslint-plugin-es/) and enable following rules in `eslint-config-wantedly` to prevent throwing SyntaxError.

- [es/no-regexp-lookbehind-assertions](https://mysticatea.github.io/eslint-plugin-es/rules/no-regexp-lookbehind-assertions.html)
- [es/no-regexp-named-capture-groups](https://mysticatea.github.io/eslint-plugin-es/rules/no-regexp-named-capture-groups.html)