### PR TITLE
fix(prettier-config-wantedly): Use 'bracketSameLine' instead of 'jsxBracketSameLine'

### DIFF
--- a/packages/frolint/README.md
+++ b/packages/frolint/README.md
@@ -62,7 +62,7 @@ Despite its name of linter, `frolint` also formats the code with the famous `pre
   "singleQuote": false,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "jsxBracketSameLine": false,
+  "bracketSameLine": false,
   "endOfLine": "lf"
 }
 ```

--- a/packages/prettier-config-wantedly/index.json
+++ b/packages/prettier-config-wantedly/index.json
@@ -6,6 +6,6 @@
   "singleQuote": false,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "jsxBracketSameLine": false,
+  "bracketSameLine": false,
   "endOfLine": "lf"
 }


### PR DESCRIPTION
## Why

`jsxBracketSameLine` is deprecated in prettier 2.4
cf. https://prettier.io/blog/2021/09/09/2.4.0.html

## What

Replaced `jsxBracketSameLine` with `bracketSameLine`.
