### PR TITLE
[GitHub Actions] Use new Environment File instead of set-output

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Restore cache for yarn and lerna
         uses: actions/cache@v2.1.6


### PR DESCRIPTION
## Why

GitHub Actions `set-output` command is deprecated.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## What

I migrated to `$GITHUB_OUTPUT`.