### PR TITLE
Fix(eslint-pluigin-prettier): Remove `eslint-plugin-prettier`

### DIFF
--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/index.test.js.snap
@@ -38,7 +38,6 @@ Array [
   "react",
   "use-macros",
   "@typescript-eslint",
-  "prettier",
   "jest",
   "jsx-a11y",
   "import",

--- a/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly-typescript/__tests__/__snapshots__/without-react.test.js.snap
@@ -35,7 +35,6 @@ exports[`eslint-config-wantedly-typescript/without-react should match snapshot f
 Array [
   "use-macros",
   "@typescript-eslint",
-  "prettier",
   "jest",
   "jsx-a11y",
   "import",

--- a/packages/eslint-config-wantedly-typescript/package.json
+++ b/packages/eslint-config-wantedly-typescript/package.json
@@ -11,7 +11,6 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^25.7.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",
-    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-use-macros": "^3.0.0",

--- a/packages/eslint-config-wantedly-typescript/without-react.js
+++ b/packages/eslint-config-wantedly-typescript/without-react.js
@@ -17,7 +17,7 @@ module.exports = {
     },
     sourceType: "module",
   },
-  plugins: ["import", "jsx-a11y", "jest", "prettier", "@typescript-eslint", "use-macros"],
+  plugins: ["import", "jsx-a11y", "jest", "@typescript-eslint", "use-macros"],
   rules: {
     "array-callback-return": "off",
     "arrow-body-style": ["off"],

--- a/packages/eslint-config-wantedly/README.md
+++ b/packages/eslint-config-wantedly/README.md
@@ -10,7 +10,6 @@ Using `babel-eslint`
 
 - eslint:recommended
 - [plugin:react/recommended](https://github.com/yannickcr/eslint-plugin-react#recommended)
-- [prettier](https://github.com/prettier/eslint-plugin-prettier#recommended-configuration)
 
 ### Plugins
 
@@ -18,7 +17,6 @@ Using `babel-eslint`
 - [import](https://github.com/benmosher/eslint-plugin-import)
 - [jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y)
 - [jest](https://github.com/jest-community/eslint-plugin-jest)
-- [prettier](https://github.com/prettier/eslint-plugin-prettier)
 
 ### Rules
 

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/index.test.js.snap
@@ -37,7 +37,6 @@ Array [
   "react",
   "es",
   "use-macros",
-  "prettier",
   "jest",
   "jsx-a11y",
   "import",

--- a/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
+++ b/packages/eslint-config-wantedly/__tests__/__snapshots__/without-react.test.js.snap
@@ -35,7 +35,6 @@ exports[`eslint-config-wantedly/without-react should match snapshot for: plugins
 Array [
   "es",
   "use-macros",
-  "prettier",
   "jest",
   "jsx-a11y",
   "import",

--- a/packages/eslint-config-wantedly/package.json
+++ b/packages/eslint-config-wantedly/package.json
@@ -11,7 +11,6 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^25.7.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",
-    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-use-macros": "^3.0.0"

--- a/packages/eslint-config-wantedly/without-react.js
+++ b/packages/eslint-config-wantedly/without-react.js
@@ -17,7 +17,7 @@ module.exports = {
     },
     sourceType: "module",
   },
-  plugins: ["import", "jsx-a11y", "jest", "prettier", "use-macros", "es"],
+  plugins: ["import", "jsx-a11y", "jest", "use-macros", "es"],
   rules: {
     "array-callback-return": "off",
     "arrow-body-style": ["off"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3757,13 +3757,6 @@ eslint-plugin-jsx-a11y@^6.5.1:
     language-tags "^1.0.5"
     minimatch "^3.0.4"
 
-eslint-plugin-prettier@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
-  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 eslint-plugin-react-hooks@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz#318dbf312e06fab1c835a4abef00121751ac1172"
@@ -4004,11 +3997,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
   version "3.2.5"
@@ -7233,13 +7221,6 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier@^2.4.1:
   version "2.4.1"


### PR DESCRIPTION
## Why

issue: https://github.com/wantedly/frolint/issues/1101

## What

Previously `frolint` contained a dependency called `eslint-plugin-prettier`.
This runs Prettier on top of ESLint and was actually included in the ESLint config in `frolint`.

But from the following code like `applyPrettier`,
indicates that from the beginning Prettier was run independently as a separate entity.

https://github.com/wantedly/frolint/blob/master/packages/frolint/src/commands/DefaultCommand.ts#L153

Therefore, `applyESLint`step means that Prettier is being executed in vain, so
removed `eslint-plugin-prettier`.

## Check operation

Created `frolint` symbolic link with `yarn link` and executed frolint command in wontedly-frontend.