### PR TITLE
Stop recommending styled-components/macros

### DIFF
--- a/packages/eslint-config-wantedly/index.js
+++ b/packages/eslint-config-wantedly/index.js
@@ -37,6 +37,6 @@ module.exports = {
     "react-hooks/exhaustive-deps": "warn",
 
     // eslint-plugin-use-macros rules
-    "use-macros/styled-components": "error",
+    "use-macros/styled-components": "off",
   },
 };


### PR DESCRIPTION
## Why

styled-components/macros has been removed in v6.1: https://github.com/styled-components/styled-components/issues/4064

## What

Let's stop encouraging it; the Babel config would be just fine.