### PR TITLE
ci(dependabot): Delete reviewers field

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,4 @@ updates:
       time: "07:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 10
-    reviewers:
-      - "yamadayuki"
     versioning-strategy: increase


### PR DESCRIPTION
## Why

Ex-Wantedly member is still assigned to dependabot's Pull Requests.

## What

Delete reviewers field from configuration.
