### PR TITLE
ci: Update node.js versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
## Why

The work flows use outdated Node.js versions.

## What

Use 16~20.

