### PR TITLE
build(deps-peer): Fix typescript version constraint

### DIFF
--- a/.changeset/silent-schools-speak.md
+++ b/.changeset/silent-schools-speak.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-wantedly-typescript": patch
+---
+
+build(deps-peer): Fix TypeScript version

--- a/packages/eslint-config-wantedly-typescript/package.json
+++ b/packages/eslint-config-wantedly-typescript/package.json
@@ -17,7 +17,7 @@
     "eslint-plugin-wantedly": "^3.2.2"
   },
   "peerDependencies": {
-    "typescript": ">=3.3.1 <5.0.0"
+    "typescript": ">=3.3.1"
   },
   "homepage": "https://github.com/wantedly/frolint",
   "keywords": [


### PR DESCRIPTION
## Why & What

It works with the latest TypeScript, so it doesn't need to narrow TS version.

