### PR TITLE
hotfix(eslint-plugin): Fix option schema

### DIFF
--- a/.changeset/dull-terms-matter.md
+++ b/.changeset/dull-terms-matter.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-use-macros": patch
+"eslint-plugin-wantedly": patch
+---
+
+hotfix(eslint-plugin): Fix option schema

--- a/packages/eslint-plugin-use-macros/__tests__/GraphQLTag.test.js
+++ b/packages/eslint-plugin-use-macros/__tests__/GraphQLTag.test.js
@@ -11,7 +11,6 @@ ruleTester.run("use-macros/graphql-tag", GraphQLTagRule, {
   valid: [
     {
       code: `import { gql } from "graphql.macro";`,
-      options: ["error"],
     },
   ],
   invalid: [
@@ -19,7 +18,6 @@ ruleTester.run("use-macros/graphql-tag", GraphQLTagRule, {
       code: `import gql from "graphql-tag";`,
       output: `import { gql } from "graphql.macro";`,
       errors: ['Please import from "graphql.macro" instead of "graphql-tag"'],
-      options: ["error"],
     },
   ],
 });

--- a/packages/eslint-plugin-use-macros/__tests__/StyledComponents.test.js
+++ b/packages/eslint-plugin-use-macros/__tests__/StyledComponents.test.js
@@ -11,7 +11,6 @@ ruleTester.run("use-macros/styled-components", StyledComponentsRule, {
   valid: [
     {
       code: `import styled from "styled-components/macro";`,
-      options: ["error"],
     },
   ],
   invalid: [
@@ -19,7 +18,6 @@ ruleTester.run("use-macros/styled-components", StyledComponentsRule, {
       code: `import styled from "styled-components";`,
       output: `import styled from "styled-components/macro";`,
       errors: ['Please import from "styled-components/macro" instead of "styled-components"'],
-      options: ["error"],
     },
   ],
 });

--- a/packages/eslint-plugin-use-macros/rules/GraphQLTag.js
+++ b/packages/eslint-plugin-use-macros/rules/GraphQLTag.js
@@ -23,11 +23,6 @@ module.exports = {
   meta: {
     type: "suggestion",
     fixable: "code",
-    schema: [
-      {
-        enum: ["error", "warn", "off"],
-      },
-    ],
   },
   create(context) {
     return {

--- a/packages/eslint-plugin-use-macros/rules/StyledComponents.js
+++ b/packages/eslint-plugin-use-macros/rules/StyledComponents.js
@@ -5,11 +5,6 @@ module.exports = {
   meta: {
     type: "suggestion",
     fixable: "code",
-    schema: [
-      {
-        enum: ["error", "warn", "off"],
-      },
-    ],
   },
   create(context) {
     return {

--- a/packages/eslint-plugin-wantedly/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/eslint-plugin-wantedly/src/__tests__/__snapshots__/index.test.ts.snap
@@ -16,13 +16,6 @@ exports[`should match snapshot 1`] = `
           "fixable": "code",
           "schema": [
             {
-              "enum": [
-                "error",
-                "warn",
-                "off",
-              ],
-            },
-            {
               "additionalProperties": false,
               "properties": {
                 "autofix": {
@@ -43,13 +36,6 @@ exports[`should match snapshot 1`] = `
           },
           "fixable": "code",
           "schema": [
-            {
-              "enum": [
-                "error",
-                "warn",
-                "off",
-              ],
-            },
             {
               "additionalProperties": false,
               "properties": {
@@ -72,13 +58,6 @@ exports[`should match snapshot 1`] = `
           "fixable": "code",
           "schema": [
             {
-              "enum": [
-                "error",
-                "warn",
-                "off",
-              ],
-            },
-            {
               "additionalProperties": false,
               "properties": {
                 "autofix": {
@@ -98,15 +77,6 @@ exports[`should match snapshot 1`] = `
             "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/nexus-enum-values-description.md",
           },
           "fixable": "code",
-          "schema": [
-            {
-              "enum": [
-                "error",
-                "warn",
-                "off",
-              ],
-            },
-          ],
           "type": "suggestion",
         },
       },
@@ -117,15 +87,6 @@ exports[`should match snapshot 1`] = `
             "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/nexus-field-description.md",
           },
           "fixable": "code",
-          "schema": [
-            {
-              "enum": [
-                "error",
-                "warn",
-                "off",
-              ],
-            },
-          ],
           "type": "suggestion",
         },
       },
@@ -137,13 +98,6 @@ exports[`should match snapshot 1`] = `
           },
           "fixable": "code",
           "schema": [
-            {
-              "enum": [
-                "error",
-                "warn",
-                "off",
-              ],
-            },
             {
               "additionalProperties": false,
               "properties": {
@@ -163,15 +117,6 @@ exports[`should match snapshot 1`] = `
           "docs": {
             "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/nexus-type-description.md",
           },
-          "schema": [
-            {
-              "enum": [
-                "error",
-                "warn",
-                "off",
-              ],
-            },
-          ],
           "type": "suggestion",
         },
       },
@@ -183,13 +128,6 @@ exports[`should match snapshot 1`] = `
           },
           "fixable": "code",
           "schema": [
-            {
-              "enum": [
-                "error",
-                "warn",
-                "off",
-              ],
-            },
             {
               "additionalProperties": false,
               "properties": {
@@ -218,13 +156,6 @@ exports[`should match snapshot 1`] = `
         "fixable": "code",
         "schema": [
           {
-            "enum": [
-              "error",
-              "warn",
-              "off",
-            ],
-          },
-          {
             "additionalProperties": false,
             "properties": {
               "autofix": {
@@ -245,13 +176,6 @@ exports[`should match snapshot 1`] = `
         },
         "fixable": "code",
         "schema": [
-          {
-            "enum": [
-              "error",
-              "warn",
-              "off",
-            ],
-          },
           {
             "additionalProperties": false,
             "properties": {
@@ -274,13 +198,6 @@ exports[`should match snapshot 1`] = `
         "fixable": "code",
         "schema": [
           {
-            "enum": [
-              "error",
-              "warn",
-              "off",
-            ],
-          },
-          {
             "additionalProperties": false,
             "properties": {
               "autofix": {
@@ -300,15 +217,6 @@ exports[`should match snapshot 1`] = `
           "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/nexus-enum-values-description.md",
         },
         "fixable": "code",
-        "schema": [
-          {
-            "enum": [
-              "error",
-              "warn",
-              "off",
-            ],
-          },
-        ],
         "type": "suggestion",
       },
     },
@@ -319,15 +227,6 @@ exports[`should match snapshot 1`] = `
           "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/nexus-field-description.md",
         },
         "fixable": "code",
-        "schema": [
-          {
-            "enum": [
-              "error",
-              "warn",
-              "off",
-            ],
-          },
-        ],
         "type": "suggestion",
       },
     },
@@ -339,13 +238,6 @@ exports[`should match snapshot 1`] = `
         },
         "fixable": "code",
         "schema": [
-          {
-            "enum": [
-              "error",
-              "warn",
-              "off",
-            ],
-          },
           {
             "additionalProperties": false,
             "properties": {
@@ -365,15 +257,6 @@ exports[`should match snapshot 1`] = `
         "docs": {
           "url": "https://github.com/wantedly/frolint/tree/master/packages/eslint-plugin-wantedly/docs/rules/nexus-type-description.md",
         },
-        "schema": [
-          {
-            "enum": [
-              "error",
-              "warn",
-              "off",
-            ],
-          },
-        ],
         "type": "suggestion",
       },
     },
@@ -385,13 +268,6 @@ exports[`should match snapshot 1`] = `
         },
         "fixable": "code",
         "schema": [
-          {
-            "enum": [
-              "error",
-              "warn",
-              "off",
-            ],
-          },
           {
             "additionalProperties": false,
             "properties": {

--- a/packages/eslint-plugin-wantedly/src/rules/__tests__/graphql-operation-name.test.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/__tests__/graphql-operation-name.test.ts
@@ -61,7 +61,7 @@ gql\`
   }
 \`;`,
       errors: ["The operation name getProject should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
     {
       name: "No operation name is specified for a query",

--- a/packages/eslint-plugin-wantedly/src/rules/__tests__/graphql-pascal-case-type-name.test.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/__tests__/graphql-pascal-case-type-name.test.ts
@@ -83,7 +83,7 @@ ruleTester.run(RULE_NAME, RULE, {
   }
 \`;`,
       errors: ["The interface type node should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
     {
       name: "Type name is fixed by plugin",
@@ -100,7 +100,7 @@ ruleTester.run(RULE_NAME, RULE, {
   }
 \`;`,
       errors: ["The object type foo should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
     {
       name: "Fragment name is fixed by plugin",
@@ -115,7 +115,7 @@ ruleTester.run(RULE_NAME, RULE, {
   }
 \`;`,
       errors: ["The fragment fooFragment should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
     {
       name: "Nested fragment name is fixed by plugin",
@@ -132,7 +132,7 @@ ruleTester.run(RULE_NAME, RULE, {
   \$\{BarFragment\}
 \`;`,
       errors: ["The fragment fooFragment should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
     {
       name: "Nested fragment name is fixed by plugin 2",
@@ -149,7 +149,7 @@ ruleTester.run(RULE_NAME, RULE, {
   }
 \`;`,
       errors: ["The fragment fooFragment should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
   ],
 });

--- a/packages/eslint-plugin-wantedly/src/rules/__tests__/nexus-camel-case-field-name.test.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/__tests__/nexus-camel-case-field-name.test.ts
@@ -39,7 +39,6 @@ const User = objectType({
         "The field Profile should be camelCase",
         "The field Posts should be camelCase",
       ],
-      options: ["error"],
     },
     {
       name: "Auto fix enabled",
@@ -78,7 +77,7 @@ const User = objectType({
         "The field Profile should be camelCase",
         "The field Posts should be camelCase",
       ],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
   ],
 });

--- a/packages/eslint-plugin-wantedly/src/rules/__tests__/nexus-pascal-case-type-name.test.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/__tests__/nexus-pascal-case-type-name.test.ts
@@ -31,7 +31,7 @@ const Foo = objectType({
   },
 });`,
       errors: ["The object type name foo should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
     {
       name: "Union type name is not PascalCase",
@@ -54,7 +54,7 @@ const MediaType = unionType({
   },
 });`,
       errors: ["The union type name mediaType should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
     {
       name: "Scalar type name is not PascalCase",
@@ -87,7 +87,7 @@ const DateScalar = scalarType({
   },
 });`,
       errors: ["The scalar type name date should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
     {
       name: "Interface type name is not PascalCase",
@@ -106,7 +106,7 @@ const Node = interfaceType({
   },
 });`,
       errors: ["The interface type name node should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
     {
       name: "Input type name is not PascalCase",
@@ -127,7 +127,7 @@ export const InputType = inputObjectType({
   },
 });`,
       errors: ["The input object type name inputType should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
     {
       name: "Enum type is not Pascal case",
@@ -144,7 +144,7 @@ const Episode = enumType({
   description: "The first Star Wars episodes released",
 });`,
       errors: ["The enum type name episode should be PascalCase"],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
   ],
 });

--- a/packages/eslint-plugin-wantedly/src/rules/__tests__/nexus-upper-case-enum-members.test.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/__tests__/nexus-upper-case-enum-members.test.ts
@@ -44,7 +44,7 @@ const Episode = enumType({
         "The enum member `Episode.empire` should be UPPER_CASE",
         "The enum member `Episode.jedi` should be UPPER_CASE",
       ],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
 
     {
@@ -89,7 +89,7 @@ const Episode = enumType({
         "The enum member `Episode.empire` should be UPPER_CASE",
         "The enum member `Episode.jedi` should be UPPER_CASE",
       ],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
 
     {
@@ -122,7 +122,7 @@ const Episode = enumType({
         "The enum member `Episode.empire` should be UPPER_CASE",
         "The enum member `Episode.jedi` should be UPPER_CASE",
       ],
-      options: ["error", { autofix: true }],
+      options: [{ autofix: true }],
     },
 
     {

--- a/packages/eslint-plugin-wantedly/src/rules/graphql-operation-name.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/graphql-operation-name.ts
@@ -26,9 +26,6 @@ export const RULE: Rule.RuleModule = {
     fixable: "code",
     schema: [
       {
-        enum: ["error", "warn", "off"],
-      },
-      {
         type: "object",
         properties: {
           autofix: {

--- a/packages/eslint-plugin-wantedly/src/rules/graphql-pascal-case-type-name.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/graphql-pascal-case-type-name.ts
@@ -79,9 +79,6 @@ export const RULE: Rule.RuleModule = {
     fixable: "code",
     schema: [
       {
-        enum: ["error", "warn", "off"],
-      },
-      {
         type: "object",
         properties: {
           autofix: {

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-camel-case-field-name.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-camel-case-field-name.ts
@@ -20,9 +20,6 @@ export const RULE: Rule.RuleModule = {
     fixable: "code",
     schema: [
       {
-        enum: ["error", "warn", "off"],
-      },
-      {
         type: "object",
         properties: {
           autofix: {

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-enum-values-description.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-enum-values-description.ts
@@ -9,11 +9,6 @@ export const RULE: Rule.RuleModule = {
   meta: {
     type: "suggestion",
     fixable: "code",
-    schema: [
-      {
-        enum: ["error", "warn", "off"],
-      },
-    ],
     docs: {
       url: docsUrl(RULE_NAME),
     },

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-field-description.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-field-description.ts
@@ -12,11 +12,6 @@ export const RULE: Rule.RuleModule = {
   meta: {
     type: "suggestion",
     fixable: "code",
-    schema: [
-      {
-        enum: ["error", "warn", "off"],
-      },
-    ],
     docs: {
       url: docsUrl(RULE_NAME),
     },

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-pascal-case-type-name.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-pascal-case-type-name.ts
@@ -20,9 +20,6 @@ export const RULE: Rule.RuleModule = {
     fixable: "code",
     schema: [
       {
-        enum: ["error", "warn", "off"],
-      },
-      {
         type: "object",
         properties: {
           autofix: {

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-type-description.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-type-description.ts
@@ -11,11 +11,6 @@ const FUNCTION_WHITELIST = ["objectType", "unionType", "scalarType", "interfaceT
 export const RULE: Rule.RuleModule = {
   meta: {
     type: "suggestion",
-    schema: [
-      {
-        enum: ["error", "warn", "off"],
-      },
-    ],
     docs: {
       url: docsUrl(RULE_NAME),
     },

--- a/packages/eslint-plugin-wantedly/src/rules/nexus-upper-case-enum-members.ts
+++ b/packages/eslint-plugin-wantedly/src/rules/nexus-upper-case-enum-members.ts
@@ -17,9 +17,6 @@ export const RULE: Rule.RuleModule = {
     fixable: "code",
     schema: [
       {
-        enum: ["error", "warn", "off"],
-      },
-      {
         type: "object",
         properties: {
           autofix: {


### PR DESCRIPTION
## Why

Some plugin's options schema is wrong.

Exected

```js
{
    "wantedly/nexus-camel-case-field-name": [
        "error",
        {
            autofix: true,
        },
    ],
}
```

Actual
```js
{
    "wantedly/nexus-camel-case-field-name": [
        "error",
        "error",
        {
            autofix: true,
        },
    ],
}
```

## What

Fixed.

cf. https://eslint.org/docs/latest/extend/custom-rules#options-schemas

