### PR TITLE
ci: Update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 
@@ -21,7 +21,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Restore cache for yarn and lerna
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v6
         id: yarn-cache
         with:
           path: |
@@ -49,10 +49,10 @@ jobs:
         node-version: [20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v7
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -61,7 +61,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Restore cache for yarn and lerna
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v6
         id: yarn-cache
         with:
           path: |
@@ -89,10 +89,10 @@ jobs:
         node-version: [20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v7
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -101,7 +101,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Restore cache for yarn and lerna
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v6
         id: yarn-cache
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
-      - name: Setup Node.js 18.x
-        uses: actions/setup-node@v2
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v7
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - run: yarn install --frozen-lockfile
-      - run: yarn lerna bootstrap
       - run: yarn build
 
       - name: Create Release Pull Request or Publish to npm


### PR DESCRIPTION
## Why

frolint の CI が全ジョブ失敗しており、master を含めどのブランチでも通らない。

原因は `actions/cache@v3.3.2` の廃止。GitHub が deprecated バージョンのリクエストを自動失敗させるようになり、「Set up job」段階で全ジョブが落ちている。コードは一切実行されていない。

> This request has been automatically failed because it uses a deprecated version of `actions/cache: v3.3.2`.
> https://github.com/wantedly/frolint/actions/runs/34115354368/job/101720754749

2026-09-03 の実行は成功していたため、この間に強制失敗が発効した。

同じ理由で release.yml も危うい。`actions/checkout@v2` / `actions/setup-node@v2` は Node16 ランタイムであり、GitHub 側のフォールバックで辛うじて動いている状態。加えて Node 18.x は EOL 済みで、CI が 20.x / 22.x でテストしているのにリリースビルドだけ 18.x という不整合もある。

今回の失敗は「古いパッチバージョンにピン留めしたまま放置した」ことが根本原因のため、再発防止まで含めて対応したい。

## Why not

`changesets/action@v1` は据え置き。v2 は input 名のリネーム（`publish` → `publish-script` 等）と `github-token` の渡し方変更を含む破壊的変更が多く、リリースフローは master マージまで実地検証できないため、このPRのスコープからは外す。v1 タグは node24 ランタイムに更新済みで、ランタイム起因の廃止リスクはない。

## What

- 全ワークフローの actions を最新メジャーへ更新
  - `actions/cache` v3.3.2 → v6
  - `actions/checkout` v4.1.1 / v2 → v7
  - `actions/setup-node` v4.0.0 / v2 → v7
- バージョン指定をパッチピンからメジャータグへ変更。パッチ単位の廃止追従で CI を落とさないため
- release.yml の Node を 18.x → 20.x（CI の matrix 下限に合わせた）
- release.yml の `yarn lerna bootstrap` を削除。`postinstall` で既に実行済みで冗長

破壊的変更は確認済みで、いずれもこのリポジトリには影響しない。

- checkout v5 / cache v5 はランナー 2.327.1 以上を要求 → ホストランナーは 2.337.0
- checkout v7 は `pull_request_target` での fork PR checkout をブロック → labeler.yml は checkout していない
- setup-node v6 は自動キャッシュを npm のみに制限 → 本リポジトリは `cache:` を使わず `actions/cache` を自前で使用

⚠️ release.yml は master マージ後の push でしか動かないため、未検証。
