### PR TITLE
Publish to GitHub Packages and keep publishing to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,14 @@ jobs:
   create-release-pr:
     name: Create Release PR
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js 18.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 
@@ -26,11 +28,73 @@ jobs:
       - run: yarn lerna bootstrap
       - run: yarn build
 
-      - name: Create Release Pull Request or Publish to npm
+      # setup-node writes the //npm.pkg.github.com/:_authToken line the publish
+      # below needs. The repository has no .npmrc of its own to hold it.
+      - name: Setup Node.js 18.x for GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          registry-url: https://npm.pkg.github.com
+          scope: "@wantedly"
+
+      - name: Create Release Pull Request or Publish to GitHub Packages
         id: changesets
         uses: changesets/action@v1
         with:
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Publish to npm without @wantedly scope
+  release-to-npm:
+    runs-on: ubuntu-latest
+    needs: create-release-pr
+    if: needs.create-release-pr.outputs.published == 'true'
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Pull latest changes
+        run: git pull origin master
+
+      - name: Setup Node.js 18.x for npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          registry-url: https://registry.npmjs.org
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Bootstrap
+        run: yarn lerna bootstrap
+
+      - name: Build
+        run: yarn build
+
+      # Strip the @wantedly scope everywhere it appears, not just from the package
+      # names: the built output and the shipped configs require each other by name.
+      - name: Update package names for npm
+        run: |
+          set -euo pipefail
+          grep -rl '@wantedly/' packages \
+            --include='*.js' --include='*.ts' --include='*.d.ts' --include='*.json' --exclude-dir=node_modules |
+            xargs -r sed -i 's|@wantedly/||g'
+          for file in packages/*/package.json; do
+            jq '.publishConfig.registry = "https://registry.npmjs.org"' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+          done
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          # --no-verify: the pre-commit hook lints the tree, and the sources have
+          # just been rewritten to names that only exist on npm, not in node_modules.
+          git commit --no-verify -m "temp: change package names for npm"
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn lerna publish from-package --yes --no-verify-access

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,9 @@ jobs:
 
       # setup-node writes the //npm.pkg.github.com/:_authToken line the publish
       # below needs. The repository has no .npmrc of its own to hold it.
-      - name: Setup Node.js 18.x for GitHub Packages
+      - name: Setup the GitHub Packages registry
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
           registry-url: https://npm.pkg.github.com
           scope: "@wantedly"
 


### PR DESCRIPTION
## WHY

Releases to npm are currently published with a granular access token.
That token has to be rotated every 90 days, and the release stops once it expires.
Moving the publish target to GitHub Packages removes the problem.

Consumers still reference the old names on npm, so publishing to npm continues during the migration period.

This PR touches only `.github/workflows/release.yml`.
The package rename and the references that follow it live in the base PR.

## WHAT

The release job is split in two.

### `create-release-pr` (publish to GitHub Packages)

- After the build, runs `actions/setup-node` again with `registry-url: https://npm.pkg.github.com` and `scope: "@wantedly"`, then publishes through `changesets/action`
- It is placed after install because putting it earlier would point the resolution of public dependencies at GitHub Packages as well
- Authentication uses the `GITHUB_TOKEN` that Actions issues per job. This repository has `default_workflow_permissions: write`, so `packages: write` is granted as long as no `permissions:` block is written
- Passes `outputs.published` to the job behind it

### `release-to-npm` (publish to npm)

- Triggered by `needs: create-release-pr` and `if: needs.create-release-pr.outputs.published == 'true'`
- Strips the scope with `grep -rl '@wantedly/' | xargs sed`, rewrites the registry to npmjs with `jq`, and publishes with `lerna publish from-package`
- The stripping covers the build artifacts as well as `package.json`. Files such as `packages/frolint/lib/utils/prettier.js` require the scoped names, so restoring only the name in `package.json` would ship a broken package to npm
- Authentication uses `secrets.NPM_TOKEN`

## What to look at in review

- `set -euo pipefail` is there because `grep -rl` exits 1 when it matches nothing, which would otherwise let the whole pipe count as a success and publish scoped names to npm as a brand new package without restoring them
- `git commit --no-verify` is used because husky's pre-commit runs ESLint through lint-staged, and it always fails right after the scope has been stripped since the config files can no longer be resolved
- The publish order is GitHub Packages first, npm second. The other way round, a failure on the unverified GitHub Packages path would also stop the existing supply to npm
- No `permissions:` block is added. The repository default (`default_workflow_permissions: write`) grants the necessary scopes. Being explicit would take `contents: write`, `pull-requests: write` and `packages: write`, but publish only runs on master and cannot be verified by a PR check, so missing one would only surface after the merge. Whether to be explicit is left to the reviewer

## Merge order

Merge the base PR (the rename) first.
If this PR lands first, publishing to GitHub Packages fails with the unscoped names, the `release-to-npm` job does not meet `published == 'true'` and is skipped, and the supply to npm that consumers still reference stops.

## Note

Publish only runs after a merge to master, so this job layout cannot be verified by a PR check.
The first release after the merge is the only real verification.
